### PR TITLE
feat: encrypted ebs and gp3

### DIFF
--- a/modules/terraform-zscc-asg-aws/README.md
+++ b/modules/terraform-zscc-asg-aws/README.md
@@ -35,6 +35,8 @@ No modules.
 | [aws_launch_template.cc_launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [null_resource.error_checker](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_ami.cloudconnector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ebs_default_kms_key.current_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_alias.current_kms_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 
 ## Inputs
 
@@ -43,6 +45,7 @@ No modules.
 | <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector Instance size. Determined by and needs to match the Cloud Connector Portal provisioning template configuration | `string` | `"small"` | no |
 | <a name="input_cc_subnet_ids"></a> [cc\_subnet\_ids](#input\_cc\_subnet\_ids) | Cloud Connector EC2 Instance subnet IDs list | `list(string)` | n/a | yes |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"m5.large"` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | (Optional) Type of volume. Valid values include standard, gp2, gp3, io1, io2, sc1, or st1. Defaults to gp3 | `string` | `"gp3"` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Populate any custom user defined tags from a map | `map(string)` | `{}` | no |
 | <a name="input_health_check_grace_period"></a> [health\_check\_grace\_period](#input\_health\_check\_grace\_period) | The amount of time until EC2 Auto Scaling performs the first health check on new instances after they are put into service. Default is 15 minutes | `number` | `900` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM instance profile ID assigned to Cloud Connector | `list(string)` | n/a | yes |

--- a/modules/terraform-zscc-asg-aws/main.tf
+++ b/modules/terraform-zscc-asg-aws/main.tf
@@ -27,6 +27,19 @@ data "aws_ami" "cloudconnector" {
 
 
 ################################################################################
+# Retrieve the default AWS KMS key in the current region for EBS encryption
+################################################################################
+data "aws_ebs_default_kms_key" "current_kms_key" {
+}
+
+################################################################################
+# Retrieve an alias for the KMS key for EBS encryption
+################################################################################
+data "aws_kms_alias" "current_kms_arn" {
+  name = data.aws_ebs_default_kms_key.current_kms_key.key_arn
+}
+
+################################################################################
 # Create launch template for Cloud Connector autoscaling group instance creation. 
 # Mgmt and service interface device indexes are swapped to support ASG + GWLB 
 # instance association
@@ -65,6 +78,19 @@ resource "aws_launch_template" "cc_launch_template" {
     device_index                = 1
     security_groups             = [element(var.mgmt_security_group_id, 0)]
     associate_public_ip_address = false
+  }
+
+  ebs_optimized = true
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      kms_key_id            = data.aws_kms_alias.current_kms_arn.target_key_arn
+      volume_type           = var.ebs_volume_type
+    }
   }
 
   lifecycle {

--- a/modules/terraform-zscc-asg-aws/variables.tf
+++ b/modules/terraform-zscc-asg-aws/variables.tf
@@ -180,3 +180,9 @@ variable "lifecyclehook_instance_terminate_wait_time" {
   description = "The maximum amount of time to wait in terminating:wait state on instance termination"
   default     = 600
 }
+
+variable "ebs_volume_type" {
+  type        = string
+  description = "(Optional) Type of volume. Valid values include standard, gp2, gp3, io1, io2, sc1, or st1. Defaults to gp3"
+  default     = "gp3"
+}

--- a/modules/terraform-zscc-ccvm-aws/README.md
+++ b/modules/terraform-zscc-ccvm-aws/README.md
@@ -34,6 +34,8 @@ No modules.
 | [aws_network_interface.cc_vm_nic_index_4](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [null_resource.error_checker](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_ami.cloudconnector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ebs_default_kms_key.current_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_alias.current_kms_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_network_interface.cc_vm_nic_index_1_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interface) | data source |
 | [aws_network_interface.cc_vm_nic_index_2_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interface) | data source |
 | [aws_network_interface.cc_vm_nic_index_3_eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interface) | data source |
@@ -46,6 +48,7 @@ No modules.
 | <a name="input_cc_count"></a> [cc\_count](#input\_cc\_count) | Default number of Cloud Connector appliances to create | `number` | `1` | no |
 | <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector Instance size. Determined by and needs to match  the Cloud Connector Portal provisioning template configuration | `string` | `"small"` | no |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"m5.large"` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | (Optional) Type of volume. Valid values include standard, gp2, gp3, io1, io2, sc1, or st1. Defaults to gp3 | `string` | `"gp3"` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Populate any custom user defined tags from a map | `map(string)` | `{}` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM instance profile ID assigned to Cloud Connector | `list(string)` | n/a | yes |
 | <a name="input_instance_key"></a> [instance\_key](#input\_instance\_key) | SSH Key for instances | `string` | n/a | yes |

--- a/modules/terraform-zscc-ccvm-aws/variables.tf
+++ b/modules/terraform-zscc-ccvm-aws/variables.tf
@@ -102,3 +102,9 @@ variable "iam_instance_profile" {
   type        = list(string)
   description = "IAM instance profile ID assigned to Cloud Connector"
 }
+
+variable "ebs_volume_type" {
+  type        = string
+  description = "(Optional) Type of volume. Valid values include standard, gp2, gp3, io1, io2, sc1, or st1. Defaults to gp3"
+  default     = "gp3"
+}


### PR DESCRIPTION
default deployment to use gp3 instead of gp3 and encrypt the volume with aws default kms keys