### PR TITLE
Bug 135151 vpc changes

### DIFF
--- a/modules/terraform-zscc-network-aws/outputs.tf
+++ b/modules/terraform-zscc-network-aws/outputs.tf
@@ -1,6 +1,6 @@
 output "vpc_id" {
   description = "VPC ID"
-  value       = data.aws_vpc.vpc_selected.id
+  value       = try(data.aws_vpc.vpc_selected[0].id, aws_vpc.vpc[0].id)
 }
 
 output "cc_subnet_ids" {


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/issues/29023

These changes are to address the above bug related to the aws_vpc being referenced after a data source after being created by terraform. Future changes result in that data source read operation getting delayed and forcing the dependency resources (like aws_subnet) to be recreated incorrectly instead of updating in-place.