### PR TITLE
fix: default security group modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.2.1 (February, 3, 2024)
+BUG FIXES:
+* fix: remove var.gwlb_enabled condition for ingress_cc_service_all
+* fix: add ingress rule ingress_cc_service_https_local for default implicit TCP/443 communication minimum between Cloud Connector Service Interfaces within a VPC cluster
+
 ## v1.2.0 (December 16, 2023)
 FEATURES:
 * feat: add optional cc_tags IAM Policy for AWS Workload Tags support with Cloud Connector Instance IAM Role creation. Permissions include:

--- a/modules/terraform-zscc-sg-aws/README.md
+++ b/modules/terraform-zscc-sg-aws/README.md
@@ -37,6 +37,7 @@ No modules.
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_geneve](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_cc_service_https_local](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_security_group.cc_mgmt_sg_selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_security_group.cc_service_sg_selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_vpc.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |

--- a/modules/terraform-zscc-sg-aws/main.tf
+++ b/modules/terraform-zscc-sg-aws/main.tf
@@ -93,12 +93,22 @@ data "aws_security_group" "cc_service_sg_selected" {
 #Default required ingress connectivity
 resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_health_check" {
   count             = var.byo_security_group == false ? var.sg_count : 0
-  description       = "CC Service TCP health probe"
+  description       = "Required: CC Service TCP health probe"
   security_group_id = aws_security_group.cc_service_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
   from_port         = var.http_probe_port
   ip_protocol       = "tcp"
   to_port           = var.http_probe_port
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_https_local" {
+  count             = var.byo_security_group == false ? var.sg_count : 0
+  description       = "Required: CC inbound internal VPC cluster TCP 443 communication"
+  security_group_id = aws_security_group.cc_service_sg[count.index].id
+  cidr_ipv4         = data.aws_vpc.selected.cidr_block
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
 }
 
 #Default required egress connectivity
@@ -153,10 +163,11 @@ resource "aws_vpc_security_group_egress_rule" "egress_cc_service_geneve" {
   to_port           = 6081
 }
 
+
 #Default required for non-GWLB deployments
 resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_all" {
-  count             = var.byo_security_group == false && var.gwlb_enabled == false ? var.sg_count : 0
-  description       = "Allow all VPC traffic"
+  count             = var.byo_security_group == false ? var.sg_count : 0
+  description       = "Optional: Permit All Intra-VPC Traffic / Ensure CC Service Interfaces are able to communicate with each other freely"
   security_group_id = aws_security_group.cc_service_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
   ip_protocol       = "-1"


### PR DESCRIPTION
- remove var.gwlb_enabled condition for ingress_cc_service_all
- add ingress rule ingress_cc_service_https_local for default implicit TCP/443 communication minimum between Cloud Connector Service Interfaces within a VPC cluster

