### PR TITLE
add variable cc_route_table_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ ENHANCEMENTS:
 * refactor: add prompt to enable/disable Zscaler Remote Support security group egress rule
 * ZSEC bash script prompts for Auto Scaling Group zonal configuration
 
+BUG FIXES:
+* fix: add variable cc_route_table_enabled for conditional creation of aws_route_table.cc_rt and aws_route_table_association.cc_rt_asssociation. This is to avoid conflicts for brownfield VPC requirements where a custom subnet route table already exists to just tell terraform not to implicitly create a new one
+
 ## v1.2.1 (February, 3, 2024)
 BUG FIXES:
 * fix: remove var.gwlb_enabled condition for ingress_cc_service_all

--- a/examples/base_cc_gwlb_asg/README.md
+++ b/examples/base_cc_gwlb_asg/README.md
@@ -140,8 +140,8 @@ From base_cc_gwlb_asg directory execute:
 | <a name="input_warm_pool_state"></a> [warm\_pool\_state](#input\_warm\_pool\_state) | Sets the instance state to transition to after the lifecycle hooks finish. Valid values are: Stopped (default) or Running. Ignored when 'warm\_pool\_enabled' is false | `string` | `"Stopped"` | no |
 | <a name="input_workload_count"></a> [workload\_count](#input\_workload\_count) | Default number of workload VMs to create | `number` | `2` | no |
 | <a name="input_workloads_subnets"></a> [workloads\_subnets](#input\_workloads\_subnets) | Workload Subnets to create in VPC. This is only required if you want to override the default subnets that this code creates via vpc\_cidr variable. | `list(string)` | `null` | no |
-| <a name="input_zssupport_server"></a> [zssupport\_server](#input\_zssupport\_server) | destination IP address of Zscaler Support access server. IP resolution of remotesupport.<zscaler\_customer\_cloud>.net | `string` | `"199.168.148.101/32"` | no |
 | <a name="input_zonal_asg_enabled"></a> [zonal\_asg\_enabled](#input\_zonal\_asg\_enabled) | By default, Terraform will create one Auto Scaling Group per subnet/availability zone. Set to false if you would rather create a single Auto Scaling Group containing multiple subnets/availability zones | `bool` | `false` | no |
+| <a name="input_zssupport_server"></a> [zssupport\_server](#input\_zssupport\_server) | destination IP address of Zscaler Support access server. IP resolution of remotesupport.<zscaler\_customer\_cloud>.net | `string` | `"199.168.148.101/32"` | no |
 
 ## Outputs
 

--- a/examples/cc_gwlb/README.md
+++ b/examples/cc_gwlb/README.md
@@ -105,6 +105,7 @@ From cc_gwlb directory execute:
 | <a name="input_byo_vpc_id"></a> [byo\_vpc\_id](#input\_byo\_vpc\_id) | User provided existing AWS VPC ID | `string` | `null` | no |
 | <a name="input_cc_count"></a> [cc\_count](#input\_cc\_count) | Default number of Cloud Connector appliances to create | `number` | `4` | no |
 | <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector Instance size. Determined by and needs to match the Cloud Connector Portal provisioning template configuration | `string` | `"small"` | no |
+| <a name="input_cc_route_table_enabled"></a> [cc\_route\_table\_enabled](#input\_cc\_route\_table\_enabled) | For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables | `bool` | `true` | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VPC. This is only required if you want to override the default subnets that this code creates via vpc\_cidr variable. | `list(string)` | `null` | no |
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"m6i.large"` | no |

--- a/examples/cc_gwlb/main.tf
+++ b/examples/cc_gwlb/main.tf
@@ -63,14 +63,15 @@ module "network" {
   cc_subnets        = var.cc_subnets
   route53_subnets   = var.route53_subnets
   #bring-your-own variables
-  byo_vpc        = var.byo_vpc
-  byo_vpc_id     = var.byo_vpc_id
-  byo_subnets    = var.byo_subnets
-  byo_subnet_ids = var.byo_subnet_ids
-  byo_igw        = var.byo_igw
-  byo_igw_id     = var.byo_igw_id
-  byo_ngw        = var.byo_ngw
-  byo_ngw_ids    = var.byo_ngw_ids
+  byo_vpc                = var.byo_vpc
+  byo_vpc_id             = var.byo_vpc_id
+  byo_subnets            = var.byo_subnets
+  byo_subnet_ids         = var.byo_subnet_ids
+  byo_igw                = var.byo_igw
+  byo_igw_id             = var.byo_igw_id
+  byo_ngw                = var.byo_ngw
+  byo_ngw_ids            = var.byo_ngw_ids
+  cc_route_table_enabled = var.cc_route_table_enabled
 }
 
 

--- a/examples/cc_gwlb/terraform.tfvars
+++ b/examples/cc_gwlb/terraform.tfvars
@@ -322,3 +322,9 @@
 
 #byo_mgmt_security_group_id                 = ["mgmt-sg-1"]
 #byo_service_security_group_id              = ["service-sg-1"]
+
+## 41. By default, this script will create new route table resources associated to Cloud Connector defined private subnets
+##     Uncomment, if you do NOT want to create new route tables (true or false. Default: true)
+##     By uncommenting (setting to false) this assumes that you have an existing VPC/Subnets (byo_subnets = true)
+
+#cc_route_table_enabled                     = false

--- a/examples/cc_gwlb/variables.tf
+++ b/examples/cc_gwlb/variables.tf
@@ -378,3 +378,9 @@ variable "byo_service_security_group_id" {
   description = "Service Security Group ID for Cloud Connector association"
   default     = null
 }
+
+variable "cc_route_table_enabled" {
+  type        = bool
+  description = "For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables"
+  default     = true
+}

--- a/examples/cc_gwlb_asg/README.md
+++ b/examples/cc_gwlb_asg/README.md
@@ -108,6 +108,7 @@ From cc_gwlb_asg directory execute:
 | <a name="input_byo_vpc"></a> [byo\_vpc](#input\_byo\_vpc) | Bring your own AWS VPC for Cloud Connector | `bool` | `false` | no |
 | <a name="input_byo_vpc_id"></a> [byo\_vpc\_id](#input\_byo\_vpc\_id) | User provided existing AWS VPC ID | `string` | `null` | no |
 | <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector Instance size. Determined by and needs to match the Cloud Connector Portal provisioning template configuration | `string` | `"small"` | no |
+| <a name="input_cc_route_table_enabled"></a> [cc\_route\_table\_enabled](#input\_cc\_route\_table\_enabled) | For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables | `bool` | `true` | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VPC. This is only required if you want to override the default subnets that this code creates via vpc\_cidr variable. | `list(string)` | `null` | no |
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"m6i.large"` | no |

--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -62,14 +62,15 @@ module "network" {
   cc_subnets        = var.cc_subnets
   route53_subnets   = var.route53_subnets
   #bring-your-own variables
-  byo_vpc        = var.byo_vpc
-  byo_vpc_id     = var.byo_vpc_id
-  byo_subnets    = var.byo_subnets
-  byo_subnet_ids = var.byo_subnet_ids
-  byo_igw        = var.byo_igw
-  byo_igw_id     = var.byo_igw_id
-  byo_ngw        = var.byo_ngw
-  byo_ngw_ids    = var.byo_ngw_ids
+  byo_vpc                = var.byo_vpc
+  byo_vpc_id             = var.byo_vpc_id
+  byo_subnets            = var.byo_subnets
+  byo_subnet_ids         = var.byo_subnet_ids
+  byo_igw                = var.byo_igw
+  byo_igw_id             = var.byo_igw_id
+  byo_ngw                = var.byo_ngw
+  byo_ngw_ids            = var.byo_ngw_ids
+  cc_route_table_enabled = var.cc_route_table_enabled
 }
 
 

--- a/examples/cc_gwlb_asg/terraform.tfvars
+++ b/examples/cc_gwlb_asg/terraform.tfvars
@@ -357,3 +357,9 @@
 
 #byo_mgmt_security_group_id                 = ["mgmt-sg-1"]
 #byo_service_security_group_id              = ["service-sg-1"]
+
+## 49. By default, this script will create new route table resources associated to Cloud Connector defined private subnets
+##     Uncomment, if you do NOT want to create new route tables (true or false. Default: true)
+##     By uncommenting (setting to false) this assumes that you have an existing VPC/Subnets (byo_subnets = true)
+
+#cc_route_table_enabled                     = false

--- a/examples/cc_gwlb_asg/variables.tf
+++ b/examples/cc_gwlb_asg/variables.tf
@@ -494,3 +494,9 @@ variable "byo_service_security_group_id" {
   description = "Service Security Group ID for Cloud Connector association"
   default     = null
 }
+
+variable "cc_route_table_enabled" {
+  type        = bool
+  description = "For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables"
+  default     = true
+}

--- a/examples/cc_ha/README.md
+++ b/examples/cc_ha/README.md
@@ -106,6 +106,7 @@ From cc_ha directory execute:
 | <a name="input_byo_vpc_id"></a> [byo\_vpc\_id](#input\_byo\_vpc\_id) | User provided existing AWS VPC ID | `string` | `null` | no |
 | <a name="input_cc_count"></a> [cc\_count](#input\_cc\_count) | Default number of Cloud Connector appliances to create | `number` | `2` | no |
 | <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector Instance size. Determined by and needs to match the Cloud Connector Portal provisioning template configuration | `string` | `"small"` | no |
+| <a name="input_cc_route_table_enabled"></a> [cc\_route\_table\_enabled](#input\_cc\_route\_table\_enabled) | For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables | `bool` | `true` | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VPC. This is only required if you want to override the default subnets that this code creates via vpc\_cidr variable. | `list(string)` | `null` | no |
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"m6i.large"` | no |

--- a/examples/cc_ha/main.tf
+++ b/examples/cc_ha/main.tf
@@ -63,14 +63,15 @@ module "network" {
   cc_subnets        = var.cc_subnets
   route53_subnets   = var.route53_subnets
   #bring-your-own variables
-  byo_vpc        = var.byo_vpc
-  byo_vpc_id     = var.byo_vpc_id
-  byo_subnets    = var.byo_subnets
-  byo_subnet_ids = var.byo_subnet_ids
-  byo_igw        = var.byo_igw
-  byo_igw_id     = var.byo_igw_id
-  byo_ngw        = var.byo_ngw
-  byo_ngw_ids    = var.byo_ngw_ids
+  byo_vpc                = var.byo_vpc
+  byo_vpc_id             = var.byo_vpc_id
+  byo_subnets            = var.byo_subnets
+  byo_subnet_ids         = var.byo_subnet_ids
+  byo_igw                = var.byo_igw
+  byo_igw_id             = var.byo_igw_id
+  byo_ngw                = var.byo_ngw
+  byo_ngw_ids            = var.byo_ngw_ids
+  cc_route_table_enabled = var.cc_route_table_enabled
 }
 
 

--- a/examples/cc_ha/terraform.tfvars
+++ b/examples/cc_ha/terraform.tfvars
@@ -282,6 +282,12 @@
 #byo_mgmt_security_group_id                 = ["mgmt-sg-1"]
 #byo_service_security_group_id              = ["service-sg-1"]
 
+## 34. By default, this script will create new route table resources associated to Cloud Connector defined private subnets
+##     Uncomment, if you do NOT want to create new route tables (true or false. Default: true)
+##     By uncommenting (setting to false) this assumes that you have an existing VPC/Subnets (byo_subnets = true)
+
+#cc_route_table_enabled                     = false
+
 #####################################################################################################################
 ##### Custom BYO variables. Only applicable for Lambda (non-GWLB) deployments without "base"       #####
 ##### resource requirements for Workload Route Table swaps. E.g. "cc_ha"                       #####
@@ -290,7 +296,7 @@
 ##### subnets already exist. Therefore, you must provide at least byo_vpc information              #####
 #####################################################################################################################
 
-## 34. Provide your existing Workload Route Table IDs. Route Table IDs must be added as a list and should be paired to
+## 35. Provide your existing Workload Route Table IDs. Route Table IDs must be added as a list and should be paired to
 ##     the primary Cloud Connector each Route Table would be forwarding traffic to in normal operation
 ##
 ##     Example: 

--- a/examples/cc_ha/variables.tf
+++ b/examples/cc_ha/variables.tf
@@ -327,3 +327,9 @@ variable "zssupport_server" {
   description = "destination IP address of Zscaler Support access server. IP resolution of remotesupport.<zscaler_customer_cloud>.net"
   default     = "199.168.148.101/32" #for commercial clouds
 }
+
+variable "cc_route_table_enabled" {
+  type        = bool
+  description = "For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables"
+  default     = true
+}

--- a/examples/zsec
+++ b/examples/zsec
@@ -988,6 +988,29 @@ if [[ "$byo_vpc" == "true" ]]; then
     done
 fi
 
+#If byo_subnets is true, prompt for whether to create private CC subnet route tables or not. Assumption is they already exist
+if [[ "$byo_subnets" == "true" ]]; then
+cc_route_table_response_default="no"
+    while true; do
+        echo "Existing VPC and Subnets detected..."
+        read -r -p "Do you want Terraform to create new custom Route Tables and associate with Cloud Connector subnets? [Default=$cc_route_table_response_default]: " cc_route_table_response_input
+        cc_route_table_response=${cc_route_table_response_input:-$cc_route_table_response_default}
+        case $cc_route_table_response in 
+            yes|y )
+            echo "Terraform will attempt to create new route tables and associate with existing subnets..."
+            echo "export TF_VAR_cc_route_table_enabled=true" >> .zsecrc
+        break
+        ;;
+	        no|n )
+            echo "Terraform will not create any route tables for Cloud Connector subnets..."
+            echo "Make sure existing route tables allow internet access as required per https://config.zscaler.com/zscaler.net/cloud-branch-connector"
+            echo "export TF_VAR_cc_route_table_enabled=false" >> .zsecrc
+        break
+        ;;
+	        * ) echo "invalid response. Please enter yes or no";;
+        esac
+    done 
+fi
 
 #Query for subnet creation range override
 if [[ "$byo_subnets" == "false" ]]; then

--- a/examples/zsec
+++ b/examples/zsec
@@ -285,21 +285,24 @@ if [[ "$oper" == "up" && "$dtype" != base && ! -e ./.zsecrc ]]; then
 	        7)
             echo "Zscaler Cloud $zscaler_cloud selected"
             while true; do
-                read -r -p "Manually enter your desired Zscaler Cloud name (e.g. zscalerbeta.net): " manual_cloud_name_response
+                read -r -p "Enter your desired Zscaler Cloud name (e.g. zscalerbeta.net): " manual_cloud_name_response
                 case $manual_cloud_name_response in
                 zspreview|zscalerpreview|preview|zspreview.net|zscalerpreview.net|preview.net )
                     echo "Setting zspreview.net"
                     zscaler_cloud=zspreview.net
+                    zs_env=development
                 break
                 ;;
                 zsdevel|zscalerdevel|devel|zsdevel.net|zscalerdevel.net|devel.net )
                     echo "Setting zsdevel.net"
                     zscaler_cloud=zsdevel.net
+                    zs_env=development
                 break
                 ;;
                 zsqa|zscalerqa|qa|zsqa.net|zscalerqa.net|qa.net )
                     echo "Setting zsqa.net"
                     zscaler_cloud=zsqa.net
+                    zs_env=development
                 break
                 ;;
                 *) 
@@ -950,6 +953,7 @@ if [[ "$byo_vpc" == "true" ]]; then
             yes|y ) 
             echo "Using existing subnets for Cloud Connector..."
             echo "export TF_VAR_byo_subnets=true" >> .zsecrc
+            byo_subnets=true
             if [[ "$az_count" == "1" ]]; then
                 read -r -p "$az_count availability zone chosen. Please enter the desired subnet ID (E.g subnet-05c32f4aa6bc02f8f): " byo_subnet_ids
                 echo "You entered $byo_subnet_ids"
@@ -983,6 +987,7 @@ if [[ "$byo_vpc" == "true" ]]; then
         esac
     done
 fi
+
 
 #Query for subnet creation range override
 if [[ "$byo_subnets" == "false" ]]; then
@@ -1206,6 +1211,7 @@ case $cloud_tags_response in
 done 
 
 support_access_response_default="no"
+support_server_ip_default="199.168.148.101/32"
 while true; do
     read -r -p "By default, an outbound Security Group rule is configured enabling Zscaler remote support access. Would you like to disable this rule creation? [Default=$support_access_response_default]: " support_access_response_input
     support_access_response=${support_access_response_input:-$support_access_response_default}
@@ -1218,10 +1224,15 @@ while true; do
         ;;
         no|n )
         echo "export TF_VAR_support_access_enabled=true" >> .zsecrc
-        echo "resolving remotesupport.$zscaler_cloud to IP for Security Group rule..."
-        support_server_ip=$(dig +short remotesupport.$zscaler_cloud)
-        echo "Outbound rule permitting TCP/12002 access to $support_server_ip/32 will be created"
-        echo "export TF_VAR_zssupport_server='$support_server_ip/32'" >> .zsecrc
+        if [[ "$zs_env" == "development" ]]; then
+            echo "Setting security group rule to $support_server_ip_default"
+            echo "export TF_VAR_zssupport_server='$support_server_ip_default'" >> .zsecrc
+        else
+            echo "Resolving remotesupport.$zscaler_cloud to IP for Security Group rule..."
+            support_server_ip=$(dig +short remotesupport.$zscaler_cloud)
+            echo "Outbound rule permitting TCP/12002 access to $support_server_ip/32 will be created"
+            echo "export TF_VAR_zssupport_server='$support_server_ip/32'" >> .zsecrc
+        fi
     break
         ;;
         * ) echo "invalid response. Please enter yes or no";;

--- a/modules/terraform-zscc-network-aws/README.md
+++ b/modules/terraform-zscc-network-aws/README.md
@@ -60,6 +60,7 @@ No modules.
 | <a name="input_byo_subnets"></a> [byo\_subnets](#input\_byo\_subnets) | Bring your own AWS Subnets for Cloud Connector | `bool` | `false` | no |
 | <a name="input_byo_vpc"></a> [byo\_vpc](#input\_byo\_vpc) | Bring your own AWS VPC for Cloud Connector | `bool` | `false` | no |
 | <a name="input_byo_vpc_id"></a> [byo\_vpc\_id](#input\_byo\_vpc\_id) | User provided existing AWS VPC ID | `string` | `null` | no |
+| <a name="input_cc_route_table_enabled"></a> [cc\_route\_table\_enabled](#input\_cc\_route\_table\_enabled) | For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables | `bool` | `true` | no |
 | <a name="input_cc_service_enis"></a> [cc\_service\_enis](#input\_cc\_service\_enis) | List of Cloud Connector Service ENIs for use in private workload and/or Route 53 subnet route tables with HA/non-GWLB deployments. Utilized if var.gwlb\_enabled is set to false | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_cc_subnets"></a> [cc\_subnets](#input\_cc\_subnets) | Cloud Connector Subnets to create in VPC. This is only required if you want to override the default subnets that this code creates via vpc\_cidr variable. | `list(string)` | `null` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Populate any custom user defined tags from a map | `map(string)` | `{}` | no |

--- a/modules/terraform-zscc-network-aws/main.tf
+++ b/modules/terraform-zscc-network-aws/main.tf
@@ -183,7 +183,7 @@ data "aws_subnet" "cc_subnet_selected" {
 
 # Create Route Tables for CC subnets pointing to NAT Gateway resource in each AZ or however many were specified. Optionally, point directly to IGW for public deployments
 resource "aws_route_table" "cc_rt" {
-  count  = length(data.aws_subnet.cc_subnet_selected[*].id)
+  count  = var.cc_route_table_enabled ? length(data.aws_subnet.cc_subnet_selected[*].id) : 0
   vpc_id = try(data.aws_vpc.vpc_selected[0].id, aws_vpc.vpc[0].id)
   route {
     cidr_block     = "0.0.0.0/0"
@@ -197,7 +197,7 @@ resource "aws_route_table" "cc_rt" {
 
 # CC subnet Route Table Association
 resource "aws_route_table_association" "cc_rt_asssociation" {
-  count          = length(data.aws_subnet.cc_subnet_selected[*].id)
+  count          = var.cc_route_table_enabled ? length(data.aws_subnet.cc_subnet_selected[*].id) : 0
   subnet_id      = data.aws_subnet.cc_subnet_selected[count.index].id
   route_table_id = aws_route_table.cc_rt[count.index].id
 }

--- a/modules/terraform-zscc-network-aws/variables.tf
+++ b/modules/terraform-zscc-network-aws/variables.tf
@@ -143,3 +143,9 @@ variable "byo_ngw_ids" {
   description = "User provided existing AWS NAT Gateway IDs"
   default     = null
 }
+
+variable "cc_route_table_enabled" {
+  type        = bool
+  description = "For brownfield environments where VPC subnets already exist, set to false to not create a new route table to associate to Cloud Connector subnet(s). Default is true which means module will try to create new route tables"
+  default     = true
+}


### PR DESCRIPTION
fix: add variable cc_route_table_enabled for conditional creation of aws_route_table.cc_rt and aws_route_table_association.cc_rt_asssociation. This is to avoid conflicts for brownfield VPC requirements where a custom subnet route table already exists to just tell terraform not to implicitly create a new one

misc zsec changes for zssupport tunnel in development clouds