### PR TITLE
Feature/ztw 3413 Upgrade runtime version of python to 3.12 and required terraform aws provider version

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,10 @@
 
 **Terraform configurations and modules for deploying Zscaler Cloud Connector Cluster in AWS.**
 
-## Prerequisites (You will be prompted for AWS keys and region during deployment)
+## Prerequisites 
+(You will be prompted for AWS keys and region during deployment)  
+The AWS Terraform scripts leverage Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform version 0.13.7 should be generally supported.  
+provider registry.terraform.io/hashicorp/aws v5.39.1 (minimum 5.32.0)
 
 ### AWS requirements
 1. A valid AWS account with Administrator Access to deploy required resources

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -38,7 +38,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -48,7 +48,7 @@ From base directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -40,7 +40,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -50,7 +50,7 @@ From base_1cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -40,7 +40,7 @@ From base_1cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -50,7 +50,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_1cc_zpa/versions.tf
+++ b/examples/base_1cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc/README.md
+++ b/examples/base_2cc/README.md
@@ -42,7 +42,7 @@ From base_2cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From base_2cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_2cc/versions.tf
+++ b/examples/base_2cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc_zpa/README.md
+++ b/examples/base_2cc_zpa/README.md
@@ -41,7 +41,7 @@ From base_2cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -51,7 +51,7 @@ From base_2cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_2cc_zpa/versions.tf
+++ b/examples/base_2cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb/README.md
+++ b/examples/base_cc_gwlb/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb/main.tf
+++ b/examples/base_cc_gwlb/main.tf
@@ -205,7 +205,6 @@ module "gwlb" {
   vpc_id                = module.network.vpc_id
   cc_subnet_ids         = module.network.cc_subnet_ids
   cc_service_ips        = module.cc_vm.forwarding_ip
-  cc_instance_size      = var.cc_instance_size
   http_probe_port       = var.http_probe_port
   health_check_interval = var.health_check_interval
   healthy_threshold     = var.healthy_threshold

--- a/examples/base_cc_gwlb/versions.tf
+++ b/examples/base_cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg/README.md
+++ b/examples/base_cc_gwlb_asg/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_asg/versions.tf
+++ b/examples/base_cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg_zpa/README.md
+++ b/examples/base_cc_gwlb_asg_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_asg_zpa/versions.tf
+++ b/examples/base_cc_gwlb_asg_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_zpa/README.md
+++ b/examples/base_cc_gwlb_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_zpa/main.tf
+++ b/examples/base_cc_gwlb_zpa/main.tf
@@ -207,7 +207,6 @@ module "gwlb" {
   vpc_id                = module.network.vpc_id
   cc_subnet_ids         = module.network.cc_subnet_ids
   cc_service_ips        = module.cc_vm.forwarding_ip
-  cc_instance_size      = var.cc_instance_size
   http_probe_port       = var.http_probe_port
   health_check_interval = var.health_check_interval
   healthy_threshold     = var.healthy_threshold

--- a/examples/base_cc_gwlb_zpa/versions.tf
+++ b/examples/base_cc_gwlb_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb/README.md
+++ b/examples/cc_gwlb/README.md
@@ -38,7 +38,7 @@ From cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -48,7 +48,7 @@ From cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_gwlb/main.tf
+++ b/examples/cc_gwlb/main.tf
@@ -196,7 +196,6 @@ module "gwlb" {
   vpc_id                = module.network.vpc_id
   cc_subnet_ids         = module.network.cc_subnet_ids
   cc_service_ips        = module.cc_vm.forwarding_ip
-  cc_instance_size      = var.cc_instance_size
   http_probe_port       = var.http_probe_port
   health_check_interval = var.health_check_interval
   healthy_threshold     = var.healthy_threshold

--- a/examples/cc_gwlb/versions.tf
+++ b/examples/cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb_asg/README.md
+++ b/examples/cc_gwlb_asg/README.md
@@ -37,7 +37,7 @@ From cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -47,7 +47,7 @@ From cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_gwlb_asg/versions.tf
+++ b/examples/cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_ha/README.md
+++ b/examples/cc_ha/README.md
@@ -42,7 +42,7 @@ From cc_ha directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.18 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From cc_ha directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_ha/versions.tf
+++ b/examples/cc_ha/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.18"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/terraform-zscc-asg-aws/README.md
+++ b/modules/terraform-zscc-asg-aws/README.md
@@ -15,7 +15,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -23,7 +23,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-asg-aws/versions.tf
+++ b/modules/terraform-zscc-asg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-asg-lambda-aws/README.md
+++ b/modules/terraform-zscc-asg-lambda-aws/README.md
@@ -11,13 +11,13 @@ This module creates the Lambda Function, IAM Policies, and Cloudwatch Events/Tar
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-asg-lambda-aws/main.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/main.tf
@@ -164,7 +164,7 @@ resource "aws_iam_role_policy_attachment" "lambda_logs_attachment" {
 resource "aws_lambda_function" "asg_lambda_function" {
   function_name    = "${var.name_prefix}_asg_lambda_function_${var.resource_tag}"
   handler          = "${var.asg_lambda_filename}.lambda_handler"
-  runtime          = "python3.9"
+  runtime          = "python3.12"
   filename         = "${path.module}/${var.asg_lambda_filename}.zip"
   source_code_hash = filebase64sha256("${path.module}/${var.asg_lambda_filename}.zip")
   role             = aws_iam_role.asg_lambda_iam_role.arn

--- a/modules/terraform-zscc-asg-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-bastion-aws/README.md
+++ b/modules/terraform-zscc-bastion-aws/README.md
@@ -8,13 +8,13 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-aws/versions.tf
+++ b/modules/terraform-zscc-bastion-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-ccvm-aws/README.md
+++ b/modules/terraform-zscc-ccvm-aws/README.md
@@ -8,7 +8,7 @@ This module creates all AWS EC2 instance and network interface resources needed 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -16,7 +16,7 @@ This module creates all AWS EC2 instance and network interface resources needed 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-ccvm-aws/versions.tf
+++ b/modules/terraform-zscc-ccvm-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-gwlb-aws/README.md
+++ b/modules/terraform-zscc-gwlb-aws/README.md
@@ -8,13 +8,13 @@ This module creates a Gateway Load Balancer (GWLB) and Listener resource. It als
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 
@@ -34,7 +34,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_asg_enabled"></a> [asg\_enabled](#input\_asg\_enabled) | Determines whether to set gwlb target group target\_type to 'instance' or 'ip'. If set to true, ASG uses 'instance' and no aws\_lb\_target\_group\_attachment resources need to be created | `bool` | `false` | no |
-| <a name="input_cc_instance_size"></a> [cc\_instance\_size](#input\_cc\_instance\_size) | Cloud Connector instance size as defined in the Connector portal provisioning template | `string` | `"small"` | no |
 | <a name="input_cc_service_ips"></a> [cc\_service\_ips](#input\_cc\_service\_ips) | Cloud Connector forwarding service IPs | `list(string)` | `[]` | no |
 | <a name="input_cc_subnet_ids"></a> [cc\_subnet\_ids](#input\_cc\_subnet\_ids) | Cloud Connector subnet IDs list | `list(string)` | n/a | yes |
 | <a name="input_cross_zone_lb_enabled"></a> [cross\_zone\_lb\_enabled](#input\_cross\_zone\_lb\_enabled) | Determines whether GWLB cross zone load balancing should be enabled or not | `bool` | `false` | no |

--- a/modules/terraform-zscc-gwlb-aws/variables.tf
+++ b/modules/terraform-zscc-gwlb-aws/variables.tf
@@ -56,19 +56,6 @@ variable "global_tags" {
   description = "Populate any custom user defined tags from a map"
   default     = {}
 }
-variable "cc_instance_size" {
-  type        = string
-  description = "Cloud Connector instance size as defined in the Connector portal provisioning template"
-  default     = "small"
-  validation {
-    condition = (
-      var.cc_instance_size == "small" ||
-      var.cc_instance_size == "medium" ||
-      var.cc_instance_size == "large"
-    )
-    error_message = "Input cc_instance_size must be set to an approved cc instance type."
-  }
-}
 
 variable "asg_enabled" {
   type        = bool

--- a/modules/terraform-zscc-gwlb-aws/versions.tf
+++ b/modules/terraform-zscc-gwlb-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-gwlbendpoint-aws/README.md
+++ b/modules/terraform-zscc-gwlbendpoint-aws/README.md
@@ -8,13 +8,13 @@ This module creates Gateway Load Balancer Endpoint (GWLBE) and VPC Endpoint Serv
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
+++ b/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-iam-aws/README.md
+++ b/modules/terraform-zscc-iam-aws/README.md
@@ -8,13 +8,13 @@ This module creates IAM Policies, Roles, and Instance Profile resources required
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-iam-aws/versions.tf
+++ b/modules/terraform-zscc-iam-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lambda-aws/README.md
+++ b/modules/terraform-zscc-lambda-aws/README.md
@@ -12,14 +12,14 @@ This module creates all the necessary IAM Roles/Polices, Lambda Functions/Permis
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-network-aws/README.md
+++ b/modules/terraform-zscc-network-aws/README.md
@@ -8,13 +8,13 @@ This module has multi-purpose use and is leveraged by all other Zscaler Cloud Co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-aws/versions.tf
+++ b/modules/terraform-zscc-network-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-route53-aws/README.md
+++ b/modules/terraform-zscc-route53-aws/README.md
@@ -12,13 +12,13 @@ This module can create multiple Route 53 Outbound Endpoints and Resolver Rules a
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-route53-aws/versions.tf
+++ b/modules/terraform-zscc-route53-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-sg-aws/README.md
+++ b/modules/terraform-zscc-sg-aws/README.md
@@ -8,13 +8,13 @@ This module creates Security Rules and Groups resources required for successful 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 
 ## Modules
 

--- a/modules/terraform-zscc-sg-aws/versions.tf
+++ b/modules/terraform-zscc-sg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-aws/README.md
+++ b/modules/terraform-zscc-workload-aws/README.md
@@ -8,14 +8,14 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59, <= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59, <= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 
 ## Modules

--- a/modules/terraform-zscc-workload-aws/versions.tf
+++ b/modules/terraform-zscc-workload-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59, <= 5.17"
+      version = ">= 5.32.0, <= 5.39.1"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Changed runtime version of python for lambda execution from 3.9 to 3.12 
 terraform aws provider version had to be upgraded to support python runtime 3.12 and required version at the time of publishing this PR are as follows:
 aws = {
   source = "hashicorp/aws"
   version = ">= 5.32.0, <= 5.39.1"
  }