### PR TITLE
add support for new regions and ec2 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cloud (VPC). The [examples](examples/) directory contains complete automation sc
 The AWS Terraform scripts leverage Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform
 version 0.13.7 should be generally supported.
 
--   provider registry.terraform.io/hashicorp/aws v5.39.1 (minimum 5.32.0)
+-   provider registry.terraform.io/hashicorp/aws v5.49.x (minimum 5.32.0)
 -   provider registry.terraform.io/hashicorp/random v3.3.x
 -   provider registry.terraform.io/hashicorp/local v2.2.x
 -   provider registry.terraform.io/hashicorp/null v3.1.x

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -38,7 +38,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -48,7 +48,7 @@ From base directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.4.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -40,7 +40,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -50,7 +50,7 @@ From base_1cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_1cc/terraform.tfvars
+++ b/examples/base_1cc/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_1cc/terraform.tfvars
+++ b/examples/base_1cc/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_1cc/variables.tf
+++ b/examples/base_1cc/variables.tf
@@ -92,6 +92,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -117,7 +118,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_1cc/variables.tf
+++ b/examples/base_1cc/variables.tf
@@ -96,7 +96,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -118,9 +119,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -40,7 +40,7 @@ From base_1cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -50,7 +50,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_1cc_zpa/terraform.tfvars
+++ b/examples/base_1cc_zpa/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_1cc_zpa/terraform.tfvars
+++ b/examples/base_1cc_zpa/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_1cc_zpa/variables.tf
+++ b/examples/base_1cc_zpa/variables.tf
@@ -98,6 +98,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -123,7 +124,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_1cc_zpa/variables.tf
+++ b/examples/base_1cc_zpa/variables.tf
@@ -102,7 +102,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -124,9 +125,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_1cc_zpa/versions.tf
+++ b/examples/base_1cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc/README.md
+++ b/examples/base_2cc/README.md
@@ -42,7 +42,7 @@ From base_2cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From base_2cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_2cc/terraform.tfvars
+++ b/examples/base_2cc/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_2cc/terraform.tfvars
+++ b/examples/base_2cc/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_2cc/variables.tf
+++ b/examples/base_2cc/variables.tf
@@ -92,6 +92,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -117,7 +118,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_2cc/variables.tf
+++ b/examples/base_2cc/variables.tf
@@ -96,7 +96,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -118,9 +119,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_2cc/versions.tf
+++ b/examples/base_2cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc_zpa/README.md
+++ b/examples/base_2cc_zpa/README.md
@@ -41,7 +41,7 @@ From base_2cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -51,7 +51,7 @@ From base_2cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_2cc_zpa/terraform.tfvars
+++ b/examples/base_2cc_zpa/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_2cc_zpa/terraform.tfvars
+++ b/examples/base_2cc_zpa/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_2cc_zpa/variables.tf
+++ b/examples/base_2cc_zpa/variables.tf
@@ -98,6 +98,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -123,7 +124,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_2cc_zpa/variables.tf
+++ b/examples/base_2cc_zpa/variables.tf
@@ -102,7 +102,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -124,9 +125,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_2cc_zpa/versions.tf
+++ b/examples/base_2cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb/README.md
+++ b/examples/base_cc_gwlb/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb/terraform.tfvars
+++ b/examples/base_cc_gwlb/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_cc_gwlb/terraform.tfvars
+++ b/examples/base_cc_gwlb/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_cc_gwlb/variables.tf
+++ b/examples/base_cc_gwlb/variables.tf
@@ -92,6 +92,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -117,7 +118,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_cc_gwlb/variables.tf
+++ b/examples/base_cc_gwlb/variables.tf
@@ -96,7 +96,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -118,9 +119,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_cc_gwlb/versions.tf
+++ b/examples/base_cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg/README.md
+++ b/examples/base_cc_gwlb_asg/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_asg/terraform.tfvars
+++ b/examples/base_cc_gwlb_asg/terraform.tfvars
@@ -47,10 +47,6 @@
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
 #ccvm_instance_type                         = "c6in.large"
-#ccvm_instance_type                         = "m5n.4xlarge"
-#ccvm_instance_type                         = "c5.4xlarge"
-#ccvm_instance_type                         = "m6i.4xlarge"
-#ccvm_instance_type                         = "c6i.4xlarge"
 
 ## 7. The number of Cloud Connector Subnets to create in sequential availability zones. Available input range 1-3 (Default: 2)
 ##    **** NOTE - This value will be ignored if byo_vpc / byo_subnets

--- a/examples/base_cc_gwlb_asg/terraform.tfvars
+++ b/examples/base_cc_gwlb_asg/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_cc_gwlb_asg/variables.tf
+++ b/examples/base_cc_gwlb_asg/variables.tf
@@ -90,7 +90,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -112,9 +113,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_cc_gwlb_asg/variables.tf
+++ b/examples/base_cc_gwlb_asg/variables.tf
@@ -86,6 +86,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -101,7 +102,9 @@ variable "cc_instance_size" {
   default     = "small"
   validation {
     condition = (
-      var.cc_instance_size == "small"
+      var.cc_instance_size == "small" ||
+      var.cc_instance_size == "medium" ||
+      var.cc_instance_size == "large"
     )
     error_message = "Input cc_instance_size must be set to an approved cc instance type."
   }
@@ -109,7 +112,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_cc_gwlb_asg/versions.tf
+++ b/examples/base_cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg_zpa/README.md
+++ b/examples/base_cc_gwlb_asg_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_asg_zpa/terraform.tfvars
+++ b/examples/base_cc_gwlb_asg_zpa/terraform.tfvars
@@ -47,10 +47,6 @@
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
 #ccvm_instance_type                         = "c6in.large"
-#ccvm_instance_type                         = "m5n.4xlarge"
-#ccvm_instance_type                         = "c5.4xlarge"
-#ccvm_instance_type                         = "m6i.4xlarge"
-#ccvm_instance_type                         = "c6i.4xlarge"
 
 ## 7. The number of Cloud Connector Subnets to create in sequential availability zones. Available input range 1-3 (Default: 2)
 ##    **** NOTE - This value will be ignored if byo_vpc / byo_subnets

--- a/examples/base_cc_gwlb_asg_zpa/terraform.tfvars
+++ b/examples/base_cc_gwlb_asg_zpa/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_cc_gwlb_asg_zpa/variables.tf
+++ b/examples/base_cc_gwlb_asg_zpa/variables.tf
@@ -92,6 +92,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -107,7 +108,9 @@ variable "cc_instance_size" {
   default     = "small"
   validation {
     condition = (
-      var.cc_instance_size == "small"
+      var.cc_instance_size == "small" ||
+      var.cc_instance_size == "medium" ||
+      var.cc_instance_size == "large"
     )
     error_message = "Input cc_instance_size must be set to an approved cc instance type."
   }
@@ -115,7 +118,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_cc_gwlb_asg_zpa/variables.tf
+++ b/examples/base_cc_gwlb_asg_zpa/variables.tf
@@ -96,7 +96,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -118,9 +119,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_cc_gwlb_asg_zpa/versions.tf
+++ b/examples/base_cc_gwlb_asg_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_zpa/README.md
+++ b/examples/base_cc_gwlb_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/base_cc_gwlb_zpa/terraform.tfvars
+++ b/examples/base_cc_gwlb_zpa/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/base_cc_gwlb_zpa/terraform.tfvars
+++ b/examples/base_cc_gwlb_zpa/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/base_cc_gwlb_zpa/variables.tf
+++ b/examples/base_cc_gwlb_zpa/variables.tf
@@ -98,6 +98,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -123,7 +124,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/base_cc_gwlb_zpa/variables.tf
+++ b/examples/base_cc_gwlb_zpa/variables.tf
@@ -102,7 +102,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -124,9 +125,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/base_cc_gwlb_zpa/versions.tf
+++ b/examples/base_cc_gwlb_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb/README.md
+++ b/examples/cc_gwlb/README.md
@@ -38,7 +38,7 @@ From cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -48,7 +48,7 @@ From cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_gwlb/terraform.tfvars
+++ b/examples/cc_gwlb/terraform.tfvars
@@ -51,6 +51,7 @@
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"
 #ccvm_instance_type                         = "c6i.4xlarge"
+#ccvm_instance_type                         = "c6in.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/cc_gwlb/terraform.tfvars
+++ b/examples/cc_gwlb/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/cc_gwlb/variables.tf
+++ b/examples/cc_gwlb/variables.tf
@@ -80,6 +80,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -105,7 +106,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/cc_gwlb/variables.tf
+++ b/examples/cc_gwlb/variables.tf
@@ -84,7 +84,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -106,9 +107,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/cc_gwlb/versions.tf
+++ b/examples/cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb_asg/README.md
+++ b/examples/cc_gwlb_asg/README.md
@@ -37,7 +37,7 @@ From cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -47,7 +47,7 @@ From cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_gwlb_asg/terraform.tfvars
+++ b/examples/cc_gwlb_asg/terraform.tfvars
@@ -47,10 +47,6 @@
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
 #ccvm_instance_type                         = "c6in.large"
-#ccvm_instance_type                         = "m5n.4xlarge"
-#ccvm_instance_type                         = "c5.4xlarge"
-#ccvm_instance_type                         = "m6i.4xlarge"
-#ccvm_instance_type                         = "c6i.4xlarge"
 
 ## 7. The number of Cloud Connector Subnets to create in sequential availability zones. Available input range 1-3 (Default: 2)
 ##    **** NOTE - This value will be ignored if byo_vpc / byo_subnets

--- a/examples/cc_gwlb_asg/terraform.tfvars
+++ b/examples/cc_gwlb_asg/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/cc_gwlb_asg/variables.tf
+++ b/examples/cc_gwlb_asg/variables.tf
@@ -78,7 +78,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -100,9 +101,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/cc_gwlb_asg/variables.tf
+++ b/examples/cc_gwlb_asg/variables.tf
@@ -74,6 +74,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -89,7 +90,9 @@ variable "cc_instance_size" {
   default     = "small"
   validation {
     condition = (
-      var.cc_instance_size == "small"
+      var.cc_instance_size == "small" ||
+      var.cc_instance_size == "medium" ||
+      var.cc_instance_size == "large"
     )
     error_message = "Input cc_instance_size must be set to an approved cc instance type."
   }
@@ -97,7 +100,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/cc_gwlb_asg/versions.tf
+++ b/examples/cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_ha/README.md
+++ b/examples/cc_ha/README.md
@@ -42,7 +42,7 @@ From cc_ha directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
@@ -52,7 +52,7 @@ From cc_ha directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.3.0 |

--- a/examples/cc_ha/terraform.tfvars
+++ b/examples/cc_ha/terraform.tfvars
@@ -46,6 +46,7 @@
 #ccvm_instance_type                         = "c5a.large"
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
+#ccvm_instance_type                         = "c6in.large"
 #ccvm_instance_type                         = "m5n.4xlarge"
 #ccvm_instance_type                         = "c5.4xlarge"
 #ccvm_instance_type                         = "m6i.4xlarge"

--- a/examples/cc_ha/terraform.tfvars
+++ b/examples/cc_ha/terraform.tfvars
@@ -47,10 +47,6 @@
 #ccvm_instance_type                         = "m6i.large"
 #ccvm_instance_type                         = "c6i.large"
 #ccvm_instance_type                         = "c6in.large"
-#ccvm_instance_type                         = "m5n.4xlarge"
-#ccvm_instance_type                         = "c5.4xlarge"
-#ccvm_instance_type                         = "m6i.4xlarge"
-#ccvm_instance_type                         = "c6i.4xlarge"
 
 ## 7. Cloud Connector Instance size selection. Uncomment cc_instance_size line with desired vm size to change
 ##    (Default: "small") 

--- a/examples/cc_ha/variables.tf
+++ b/examples/cc_ha/variables.tf
@@ -80,6 +80,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -105,7 +106,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/examples/cc_ha/variables.tf
+++ b/examples/cc_ha/variables.tf
@@ -84,7 +84,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -106,9 +107,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/examples/cc_ha/versions.tf
+++ b/examples/cc_ha/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = ">= 5.32.0, <= 5.49.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/zsec
+++ b/examples/zsec
@@ -552,6 +552,7 @@ first_run="yes"
             "m6i.4xlarge - Recommended"
             "m5n.4xlarge"
             "c6i.4xlarge"
+            "c6in.4xlarge"
             "c5.4xlarge"
             )
         select ccvm_instance_type in "${vm_sizes[@]}"
@@ -577,6 +578,11 @@ first_run="yes"
                     echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
                 break
                 ;;
+                5)
+                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                break
+                ;;
                 *) 
                     echo "${RED}Invalid response. Please enter a number selection${RESET}"
             esac
@@ -586,6 +592,7 @@ first_run="yes"
             "m6i.4xlarge - Recommended"
             "m5n.4xlarge"
             "c6i.4xlarge"
+            "c6in.4xlarge"
             "c5.4xlarge"
             )
         select ccvm_instance_type in "${vm_sizes[@]}"
@@ -607,6 +614,11 @@ first_run="yes"
                 break
                 ;;
                 4)
+                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                break
+                ;;
+                5)
                     echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
                     echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
                 break

--- a/examples/zsec
+++ b/examples/zsec
@@ -187,6 +187,7 @@ first_run="yes"
         "ap-southeast-1"
         "ap-southeast-2"
         "ap-southeast-3"
+        "ap-southeast-4"
         "ca-central-1"
         "cn-north-1"
         "cn-northwest-1"
@@ -194,6 +195,7 @@ first_run="yes"
         "eu-central-2"
         "eu-north-1"
         "eu-south-1"
+        "eu-south-2"
         "eu-west-1"
         "eu-west-2"
         "eu-west-3"
@@ -501,132 +503,193 @@ first_run="yes"
 
         # AWS EC2 type selection
         PS3="${CYAN}Select AWS EC2 instance type for $cc_instance_size Cloud Connector: ${RESET}"
+        
         if [[ "$cc_instance_size" == "small" ]]; then
-        vm_sizes=(
-            "m6i.large - Recommended"
-            "m5n.large"
-            "c6i.large"
-            "c6in.large"
-            "t3.medium - Not recommended for production use"
-            "t3a.medium - Not recommended for production use"
-            )
-        select ccvm_instance_type in "${vm_sizes[@]}"
-        do
-            case $REPLY in
-                1)
-                    echo "CC EC2 type: ${GREEN}m6i.large${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='m6i.large'" >> .zsecrc
-                break
-                ;;
-                2)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                3)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                4)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                5)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                6)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                *) 
-                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
-            esac
-        done
+            if [[ "$aws_region" == "eu-south-2" || "$aws_region" == "ap-southeast-4" ]]; then
+                vm_sizes=(
+                    "c6in.large - Recommended"
+                    "t3.medium - Not recommended for production use"
+                )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}c6in.large${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='c6in.large'" >> .zsecrc
+                        break
+                        ;;
+                        2)
+                            echo "CC EC2 type: ${GREEN}c6in.large${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='c6in.large'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            else
+                vm_sizes=(
+                    "m6i.large - Recommended"
+                    "m5n.large"
+                    "c6i.large"
+                    "c6in.large"
+                    "t3.medium - Not recommended for production use"
+                    "t3a.medium - Not recommended for production use"
+                    )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}m6i.large${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='m6i.large'" >> .zsecrc
+                        break
+                        ;;
+                        2)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        3)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        4)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        5)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        6)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            fi
         elif [[ "$cc_instance_size" == "medium" ]]; then
-        vm_sizes=(
-            "m6i.4xlarge - Recommended"
-            "m5n.4xlarge"
-            "c6i.4xlarge"
-            "c6in.4xlarge"
-            "c5.4xlarge"
-            )
-        select ccvm_instance_type in "${vm_sizes[@]}"
-        do
-            case $REPLY in
-                1)
-                    echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
-                break
-                ;;
-                2)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                    break
-                ;;
-                3)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                4)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                5)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                *) 
-                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
-            esac
-        done
+            if [[ "$aws_region" == "eu-south-2" || "$aws_region" == "ap-southeast-4" ]]; then
+                vm_sizes=(
+                    "c6in.4xlarge"
+                )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            else
+                vm_sizes=(
+                    "m6i.4xlarge - Recommended"
+                    "m5n.4xlarge"
+                    "c6i.4xlarge"
+                    "c6in.4xlarge"
+                    "c5.4xlarge"
+                )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
+                        break
+                        ;;
+                        2)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                            break
+                        ;;
+                        3)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        4)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        5)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            fi
         elif [[ "$cc_instance_size" == "large" ]]; then
-        vm_sizes=(
-            "m6i.4xlarge - Recommended"
-            "m5n.4xlarge"
-            "c6i.4xlarge"
-            "c6in.4xlarge"
-            "c5.4xlarge"
-            )
-        select ccvm_instance_type in "${vm_sizes[@]}"
-        do
-            case $REPLY in
-                1)
-                    echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
-                break
-                ;;
-                2)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                3)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                4)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                5)
-                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
-                break
-                ;;
-                *) 
-                    echo "${RED}Invalid response. Please enter a number selection${RESET}"
-            esac
-        done
+            if [[ "$aws_region" == "eu-south-2" || "$aws_region" == "ap-southeast-4" ]]; then
+                vm_sizes=(
+                    "c6in.4xlarge"
+                )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            else
+                vm_sizes=(
+                    "m6i.4xlarge - Recommended"
+                    "m5n.4xlarge"
+                    "c6i.4xlarge"
+                    "c6in.4xlarge"
+                    "c5.4xlarge"
+                    )
+                select ccvm_instance_type in "${vm_sizes[@]}"
+                do
+                    case $REPLY in
+                        1)
+                            echo "CC EC2 type: ${GREEN}m6i.4xlarge${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='m6i.4xlarge'" >> .zsecrc
+                        break
+                        ;;
+                        2)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        3)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        4)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        5)
+                            echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                            echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                        break
+                        ;;
+                        *) 
+                            echo "${RED}Invalid response. Please enter a number selection${RESET}"
+                    esac
+                done
+            fi
         fi
 
         read -r -p "${CYAN}Enter CC Provisioning URL${RESET} (E.g. connector.zscaler.net/api/v1/provUrl?name=aws_prov_url): " cc_vm_prov_url

--- a/examples/zsec
+++ b/examples/zsec
@@ -506,6 +506,7 @@ first_run="yes"
             "m6i.large - Recommended"
             "m5n.large"
             "c6i.large"
+            "c6in.large"
             "t3.medium - Not recommended for production use"
             "t3a.medium - Not recommended for production use"
             )
@@ -528,13 +529,18 @@ first_run="yes"
                 break
                 ;;
                 4)
-                    echo "CC EC2 type: ${GREEN}t3.medium${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='t3.medium'" >> .zsecrc
+                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
                 break
                 ;;
                 5)
-                    echo "CC EC2 type: ${GREEN}t3a.medium${RESET}"
-                    echo "export TF_VAR_ccvm_instance_type='t3a.medium'" >> .zsecrc
+                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
+                break
+                ;;
+                6)
+                    echo "CC EC2 type: ${GREEN}$ccvm_instance_type${RESET}"
+                    echo "export TF_VAR_ccvm_instance_type='$ccvm_instance_type'" >> .zsecrc
                 break
                 ;;
                 *) 

--- a/modules/terraform-zscc-asg-aws/README.md
+++ b/modules/terraform-zscc-asg-aws/README.md
@@ -15,7 +15,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -23,7 +23,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-asg-aws/variables.tf
+++ b/modules/terraform-zscc-asg-aws/variables.tf
@@ -43,6 +43,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -58,7 +59,9 @@ variable "cc_instance_size" {
   default     = "small"
   validation {
     condition = (
-      var.cc_instance_size == "small"
+      var.cc_instance_size == "small" ||
+      var.cc_instance_size == "medium" ||
+      var.cc_instance_size == "large"
     )
     error_message = "Input cc_instance_size must be set to an approved cc instance type."
   }
@@ -66,7 +69,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/modules/terraform-zscc-asg-aws/variables.tf
+++ b/modules/terraform-zscc-asg-aws/variables.tf
@@ -47,7 +47,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -69,9 +70,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/modules/terraform-zscc-asg-aws/versions.tf
+++ b/modules/terraform-zscc-asg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-asg-lambda-aws/README.md
+++ b/modules/terraform-zscc-asg-lambda-aws/README.md
@@ -14,13 +14,13 @@ This module creates the Lambda Function, IAM Policies, and Cloudwatch Events/Tar
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-asg-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-bastion-aws/README.md
+++ b/modules/terraform-zscc-bastion-aws/README.md
@@ -8,13 +8,13 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-aws/versions.tf
+++ b/modules/terraform-zscc-bastion-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-ccvm-aws/README.md
+++ b/modules/terraform-zscc-ccvm-aws/README.md
@@ -8,7 +8,7 @@ This module creates all AWS EC2 instance and network interface resources needed 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 
@@ -16,7 +16,7 @@ This module creates all AWS EC2 instance and network interface resources needed 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 
 ## Modules

--- a/modules/terraform-zscc-ccvm-aws/variables.tf
+++ b/modules/terraform-zscc-ccvm-aws/variables.tf
@@ -52,7 +52,8 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
-      var.ccvm_instance_type == "c6i.4xlarge"
+      var.ccvm_instance_type == "c6i.4xlarge" ||
+      var.ccvm_instance_type == "c6in.4xlarge"
     )
     error_message = "Input ccvm_instance_type must be set to an approved vm instance type."
   }
@@ -74,9 +75,9 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
-  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
+  large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge", "c6in.4xlarge"]
 
   valid_cc_create = (
     contains(local.small_cc_instance, var.ccvm_instance_type) && var.cc_instance_size == "small" ||

--- a/modules/terraform-zscc-ccvm-aws/variables.tf
+++ b/modules/terraform-zscc-ccvm-aws/variables.tf
@@ -48,6 +48,7 @@ variable "ccvm_instance_type" {
       var.ccvm_instance_type == "c5a.large" ||
       var.ccvm_instance_type == "m6i.large" ||
       var.ccvm_instance_type == "c6i.large" ||
+      var.ccvm_instance_type == "c6in.large" ||
       var.ccvm_instance_type == "c5.4xlarge" ||
       var.ccvm_instance_type == "m5n.4xlarge" ||
       var.ccvm_instance_type == "m6i.4xlarge" ||
@@ -73,7 +74,7 @@ variable "cc_instance_size" {
 
 # Validation to ensure that ccvm_instance_type and cc_instance_size are set appropriately
 locals {
-  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
+  small_cc_instance  = ["t3.medium", "t3a.medium", "m5n.large", "c5a.large", "m6i.large", "c6i.large", "c6in.large", "c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   medium_cc_instance = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
   large_cc_instance  = ["c5.4xlarge", "m5n.4xlarge", "m6i.4xlarge", "c6i.4xlarge"]
 

--- a/modules/terraform-zscc-ccvm-aws/versions.tf
+++ b/modules/terraform-zscc-ccvm-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-gwlb-aws/README.md
+++ b/modules/terraform-zscc-gwlb-aws/README.md
@@ -8,13 +8,13 @@ This module creates a Gateway Load Balancer (GWLB) and Listener resource. It als
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-gwlb-aws/versions.tf
+++ b/modules/terraform-zscc-gwlb-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-gwlbendpoint-aws/README.md
+++ b/modules/terraform-zscc-gwlbendpoint-aws/README.md
@@ -8,13 +8,13 @@ This module creates Gateway Load Balancer Endpoint (GWLBE) and VPC Endpoint Serv
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
+++ b/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-iam-aws/README.md
+++ b/modules/terraform-zscc-iam-aws/README.md
@@ -8,13 +8,13 @@ This module creates IAM Policies, Roles, and Instance Profile resources required
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-iam-aws/versions.tf
+++ b/modules/terraform-zscc-iam-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lambda-aws/README.md
+++ b/modules/terraform-zscc-lambda-aws/README.md
@@ -12,14 +12,14 @@ This module creates all the necessary IAM Roles/Polices, Lambda Functions/Permis
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-network-aws/README.md
+++ b/modules/terraform-zscc-network-aws/README.md
@@ -8,13 +8,13 @@ This module has multi-purpose use and is leveraged by all other Zscaler Cloud Co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-aws/versions.tf
+++ b/modules/terraform-zscc-network-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-route53-aws/README.md
+++ b/modules/terraform-zscc-route53-aws/README.md
@@ -12,13 +12,13 @@ This module can create multiple Route 53 Outbound Endpoints and Resolver Rules a
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-route53-aws/versions.tf
+++ b/modules/terraform-zscc-route53-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-sg-aws/README.md
+++ b/modules/terraform-zscc-sg-aws/README.md
@@ -8,13 +8,13 @@ This module creates Security Rules and Groups resources required for successful 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 
 ## Modules
 

--- a/modules/terraform-zscc-sg-aws/versions.tf
+++ b/modules/terraform-zscc-sg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-aws/README.md
+++ b/modules/terraform-zscc-workload-aws/README.md
@@ -8,14 +8,14 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.39.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2.0 |
 
 ## Modules

--- a/modules/terraform-zscc-workload-aws/versions.tf
+++ b/modules/terraform-zscc-workload-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.39.1"
+      version = "~> 5.32"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
ap-southeast-4 and eu-south-2 are supported by Zscaler but the only supported EC2 type similar to our recommendation is C6in.large and C6in.4xlarge. 

Adding this exception validation