### PR TITLE
additional mgmt security groups

### DIFF
--- a/modules/terraform-zscc-asg-aws/main.tf
+++ b/modules/terraform-zscc-asg-aws/main.tf
@@ -65,7 +65,7 @@ resource "aws_launch_template" "cc_launch_template" {
   network_interfaces {
     description                 = "cc management interface"
     device_index                = 1
-    security_groups             = [element(var.mgmt_security_group_id, 0)]
+    security_groups             = concat(var.mgmt_security_group_id, var.additional_mgmt_security_group_ids)
     associate_public_ip_address = false
   }
 

--- a/modules/terraform-zscc-asg-aws/main.tf
+++ b/modules/terraform-zscc-asg-aws/main.tf
@@ -65,7 +65,7 @@ resource "aws_launch_template" "cc_launch_template" {
   network_interfaces {
     description                 = "cc management interface"
     device_index                = 1
-    security_groups             = concat(var.mgmt_security_group_id, var.additional_mgmt_security_group_ids)
+    security_groups             = concat([element(var.mgmt_security_group_id, 0)], var.additional_mgmt_security_group_ids)
     associate_public_ip_address = false
   }
 

--- a/modules/terraform-zscc-asg-aws/variables.tf
+++ b/modules/terraform-zscc-asg-aws/variables.tf
@@ -83,7 +83,13 @@ locals {
 
 variable "mgmt_security_group_id" {
   type        = list(string)
-  description = "Cloud Connector EC2 Instance management subnet id"
+  description = "Cloud Connector EC2 Instance management security group id"
+}
+
+variable "additional_mgmt_security_group_ids" {
+  type        = list(string)
+  description = "Optional additional Cloud Connector EC2 Instance management security group ids to be attached to the to the management interface"
+  default     = []
 }
 
 variable "service_security_group_id" {

--- a/modules/terraform-zscc-ccvm-aws/main.tf
+++ b/modules/terraform-zscc-ccvm-aws/main.tf
@@ -91,7 +91,7 @@ resource "aws_network_interface" "cc_vm_nic_index_1" {
   count             = local.valid_cc_create ? var.cc_count : 0
   description       = "cc management interface"
   subnet_id         = element(var.mgmt_subnet_id, count.index)
-  security_groups   = [element(var.mgmt_security_group_id, count.index)]
+  security_groups   = concat([element(var.mgmt_security_group_id, count.index)], var.additional_mgmt_security_group_ids)
   source_dest_check = true
 
   attachment {

--- a/modules/terraform-zscc-ccvm-aws/variables.tf
+++ b/modules/terraform-zscc-ccvm-aws/variables.tf
@@ -97,6 +97,12 @@ variable "mgmt_security_group_id" {
   description = "Cloud Connector EC2 Instance management subnet id"
 }
 
+variable "additional_mgmt_security_group_ids" {
+  type        = list(string)
+  description = "Optional additional Cloud Connector EC2 Instance management security group ids to be attached to the to the management interface"
+  default     = []
+}
+
 variable "service_security_group_id" {
   type        = list(string)
   description = "Cloud Connector EC2 Instance service subnet id"


### PR DESCRIPTION
We have two security groups that we attach to many ec2 instance that are launched in our account.
* The first security group allows us to use EC2 Instance Connect to connect to the instance without having to open port 22 to anywhere but the ssm vpc endpoint.
* The second security group allows the instance to connect to VPC interface endpoints, such as these: https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html

We would like the ability to attach these additional security groups to the cloud connector ec2 instances that are launched.

Without being able to attach the second security group (for vpc interface endpoints), the cloud connectors fail to start because they can't connect to AWS Secrets Manager, because after a VPC interface endpoint is created, AWS's DNS directs requests to that endpoint.