### PR TITLE
Use Route53 resolver endpoint security group AWS best practices, or allow BYO security group for the outbound endpoints

### DIFF
--- a/examples/base_1cc_zpa/main.tf
+++ b/examples/base_1cc_zpa/main.tf
@@ -188,6 +188,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   gwlb_enabled             = false
@@ -202,14 +203,15 @@ module "cc_sg" {
 #    redirection to facilitate Cloud Connector ZPA service.
 ################################################################################
 module "route53" {
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/base_2cc_zpa/main.tf
+++ b/examples/base_2cc_zpa/main.tf
@@ -187,6 +187,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   gwlb_enabled             = false
@@ -219,14 +220,15 @@ module "cc_lambda" {
 #    redirection to facilitate Cloud Connector ZPA service.
 ################################################################################
 module "route53" {
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/base_cc_gwlb_asg_zpa/main.tf
+++ b/examples/base_cc_gwlb_asg_zpa/main.tf
@@ -207,6 +207,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   all_ports_egress_enabled = var.all_ports_egress_enabled
@@ -260,14 +261,15 @@ module "gwlb_endpoint" {
 #    redirection to facilitate Cloud Connector ZPA service.
 ################################################################################
 module "route53" {
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/base_cc_gwlb_zpa/main.tf
+++ b/examples/base_cc_gwlb_zpa/main.tf
@@ -189,6 +189,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   all_ports_egress_enabled = var.all_ports_egress_enabled
@@ -242,14 +243,15 @@ module "gwlb_endpoint" {
 #    redirection to facilitate Cloud Connector ZPA service.
 ################################################################################
 module "route53" {
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/cc_gwlb/main.tf
+++ b/examples/cc_gwlb/main.tf
@@ -173,6 +173,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   all_ports_egress_enabled = var.all_ports_egress_enabled
@@ -233,15 +234,16 @@ module "gwlb_endpoint" {
 #    This can optionally be enabled/disabled per variable "zpa_enabled".
 ################################################################################
 module "route53" {
-  count          = var.zpa_enabled == true ? 1 : 0
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  count                               = var.zpa_enabled == true ? 1 : 0
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -191,6 +191,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   all_ports_egress_enabled = var.all_ports_egress_enabled
@@ -251,15 +252,16 @@ module "gwlb_endpoint" {
 #    This can optionally be enabled/disabled per variable "zpa_enabled".
 ################################################################################
 module "route53" {
-  count          = var.zpa_enabled == true ? 1 : 0
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  count                               = var.zpa_enabled == true ? 1 : 0
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/examples/cc_ha/main.tf
+++ b/examples/cc_ha/main.tf
@@ -173,6 +173,7 @@ module "cc_sg" {
   resource_tag             = random_string.suffix.result
   global_tags              = local.global_tags
   vpc_id                   = module.network.vpc_id
+  zpa_enabled              = var.zpa_enabled
   http_probe_port          = var.http_probe_port
   mgmt_ssh_enabled         = var.mgmt_ssh_enabled
   gwlb_enabled             = false
@@ -223,15 +224,16 @@ module "cc_lambda" {
 #    This can optionally be enabled/disabled per variable "zpa_enabled".
 ################################################################################
 module "route53" {
-  count          = var.zpa_enabled == true ? 1 : 0
-  source         = "../../modules/terraform-zscc-route53-aws"
-  name_prefix    = var.name_prefix
-  resource_tag   = random_string.suffix.result
-  global_tags    = local.global_tags
-  vpc_id         = module.network.vpc_id
-  r53_subnet_ids = module.network.route53_subnet_ids
-  domain_names   = var.domain_names
-  target_address = var.target_address
+  count                               = var.zpa_enabled == true ? 1 : 0
+  source                              = "../../modules/terraform-zscc-route53-aws"
+  name_prefix                         = var.name_prefix
+  resource_tag                        = random_string.suffix.result
+  global_tags                         = local.global_tags
+  vpc_id                              = module.network.vpc_id
+  r53_subnet_ids                      = module.network.route53_subnet_ids
+  outbound_endpoint_security_group_id = module.cc_sg.outbound_endpoint_security_group_id
+  domain_names                        = var.domain_names
+  target_address                      = var.target_address
 }
 
 

--- a/modules/terraform-zscc-route53-aws/main.tf
+++ b/modules/terraform-zscc-route53-aws/main.tf
@@ -1,22 +1,11 @@
 ################################################################################
-# Pull in default security group information
-################################################################################
-data "aws_security_group" "selected" {
-  vpc_id = var.vpc_id
-  name   = "default"
-}
-
-
-################################################################################
 # Create Route 53 outbound endpoints per subnet IDs specified
 ################################################################################
 resource "aws_route53_resolver_endpoint" "zpa_r53_ep" {
   name      = "${var.name_prefix}-r53-resolver-ep-${var.resource_tag}"
   direction = "OUTBOUND"
 
-  security_group_ids = [
-    data.aws_security_group.selected.id
-  ]
+  security_group_ids = var.outbound_endpoint_security_group_id
 
   dynamic "ip_address" {
     for_each = var.r53_subnet_ids

--- a/modules/terraform-zscc-route53-aws/variables.tf
+++ b/modules/terraform-zscc-route53-aws/variables.tf
@@ -26,6 +26,11 @@ variable "r53_subnet_ids" {
   description = "List of Subnet IDs for the Route53 Endpoint"
 }
 
+variable "outbound_endpoint_security_group_id" {
+  type        = list(string)
+  description = "Route53 DNS Resolver Outbound Endpoint Security Group ID"
+}
+
 variable "domain_names" {
   type        = map(any)
   description = "Domain names fqdn/wildcard to have Route 53 redirect DNS requests to Cloud Connector for ZPA. Refer to terraform.tfvars step 10"

--- a/modules/terraform-zscc-sg-aws/main.tf
+++ b/modules/terraform-zscc-sg-aws/main.tf
@@ -191,3 +191,72 @@ resource "aws_vpc_security_group_egress_rule" "egress_cc_service_all" {
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "-1"
 }
+
+
+################################################################################
+# Create Security Group and Rules for Route53 DNS Resolver Outbound Endpoint
+################################################################################
+resource "aws_security_group" "outbound_endpoint_sg" {
+  count       = var.zpa_enabled == true && var.byo_security_group == false ? 1 : 0
+  name        = "${var.name_prefix}-outbound-dns-endpoint-sg-${var.resource_tag}"
+  description = "Security group for Route53 DNS Resolver Outbound Endpoint"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.global_tags,
+    { Name = "${var.name_prefix}-outbound-dns-endpoint-sg-${var.resource_tag}" }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Or use existing Route53 DNS Resolver Outbound Endpoint Security Group ID
+data "aws_security_group" "outbound_endpoint_sg_selected" {
+  count = var.byo_security_group ? length(var.byo_route53_resolver_outbound_endpoint_group_id) : 0
+  id    = element(var.byo_route53_resolver_outbound_endpoint_group_id, count.index)
+}
+
+
+#Default required ingress connectivity
+# https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/best-practices-resolver-endpoint-scaling.html
+resource "aws_vpc_security_group_ingress_rule" "ingress_outbound_endpoint_tcp_all" {
+  count             = var.zpa_enabled == true && var.byo_security_group == false ? 1 : 0
+  description       = "Required: Resolver TCP Ingress"
+  security_group_id = aws_security_group.outbound_endpoint_sg[count.index].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  ip_protocol       = "tcp"
+  to_port           = 65535
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ingress_outbound_endpoint_udp_all" {
+  count             = var.zpa_enabled == true && var.byo_security_group == false ? 1 : 0
+  description       = "Required: Resolver UDP Ingress"
+  security_group_id = aws_security_group.outbound_endpoint_sg[count.index].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  ip_protocol       = "udp"
+  to_port           = 65535
+}
+
+#Default required egress connectivity
+resource "aws_vpc_security_group_egress_rule" "egress_outbound_endpoint_tcp_all" {
+  count             = var.zpa_enabled == true && var.byo_security_group == false ? 1 : 0
+  description       = "Required: Resolver TCP Egress"
+  security_group_id = aws_security_group.outbound_endpoint_sg[count.index].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  ip_protocol       = "tcp"
+  to_port           = 65535
+}
+
+resource "aws_vpc_security_group_egress_rule" "egress_outbound_endpoint_udp_all" {
+  count             = var.zpa_enabled == true && var.byo_security_group == false ? 1 : 0
+  description       = "Required: Resolver UDP Egress"
+  security_group_id = aws_security_group.outbound_endpoint_sg[count.index].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  ip_protocol       = "udp"
+  to_port           = 65535
+}

--- a/modules/terraform-zscc-sg-aws/outputs.tf
+++ b/modules/terraform-zscc-sg-aws/outputs.tf
@@ -17,3 +17,13 @@ output "service_security_group_arn" {
   description = "Instance Service Security Group ARN"
   value       = var.byo_security_group ? data.aws_security_group.cc_service_sg_selected[*].arn : aws_security_group.cc_service_sg[*].arn
 }
+
+output "outbound_endpoint_security_group_id" {
+  description = "Route53 DNS Resolver Outbound Endpoint Security Group ID"
+  value       = var.byo_security_group ? data.aws_security_group.outbound_endpoint_sg_selected[*].id : aws_security_group.outbound_endpoint_sg[*].id
+}
+
+output "outbound_endpoint_security_group_arn" {
+  description = "Route53 DNS Resolver Outbound Endpoint Security Group ARN"
+  value       = var.byo_security_group ? data.aws_security_group.outbound_endpoint_sg_selected[*].arn : aws_security_group.outbound_endpoint_sg[*].arn
+}

--- a/modules/terraform-zscc-sg-aws/variables.tf
+++ b/modules/terraform-zscc-sg-aws/variables.tf
@@ -27,6 +27,12 @@ variable "sg_count" {
   default     = 1
 }
 
+variable "zpa_enabled" {
+  type        = bool
+  default     = false
+  description = "Configure Route 53 Security Group for ZPA DNS redirection"
+}
+
 variable "byo_security_group" {
   type        = bool
   description = "Bring your own Security Group for Cloud Connector. Setting this variable to true will effectively instruct this module to not create any resources and only reference data resources from values provided in byo_mgmt_security_group_id and byo_service_security_group_id"
@@ -42,6 +48,12 @@ variable "byo_mgmt_security_group_id" {
 variable "byo_service_security_group_id" {
   type        = list(string)
   description = "Service Security Group ID for Cloud Connector association"
+  default     = null
+}
+
+variable "byo_route53_resolver_outbound_endpoint_group_id" {
+  type        = list(string)
+  description = "Route53 Resolver Outbound Endpoint Security Group ID"
   default     = null
 }
 


### PR DESCRIPTION
Currently, the Route53 module uses the "default" security group.
Many companies have locked down the default security group. In our AWS environment, we have deleted all the inbound and outbound rules on the default security group (intentionally, to force each application to use a security group specific to it).

Additionally, the default security group does not follow AWS Best Practices for Route53 Outbound Endpoints.
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/best-practices-resolver-endpoint-scaling.html

This PR stops using the default security group, and creates a security group that follows the aws best practices.
It also allows a bring your own security group for the endpoint.
Existing formats were followed.