### PR TITLE
Fix unneeded condition in launch template count

### DIFF
--- a/modules/terraform-zscc-asg-aws/main.tf
+++ b/modules/terraform-zscc-asg-aws/main.tf
@@ -33,7 +33,7 @@ data "aws_kms_alias" "current_kms_arn" {
 # instance association
 ################################################################################
 resource "aws_launch_template" "cc_launch_template" {
-  count         = local.valid_cc_create && var.cc_instance_size == "small" ? 1 : 0
+  count         = local.valid_cc_create ? 1 : 0
   name          = "${var.name_prefix}-cc-launch-template-${var.resource_tag}"
   image_id      = var.ami_id[0]
   instance_type = var.ccvm_instance_type


### PR DESCRIPTION
Removing what appears to be an erroneous condition in the creation of the launch template.  Can't find a reason that the `cc_instance_size` would need to be small for the launch template to be created.

When cc_instance_size is a value other than "small", it results in this error upon `terraform plan`:
![image](https://github.com/user-attachments/assets/c34a8494-cea2-44aa-b907-5930b1f610da)

This change allows successful creation of the launch template and following resource in the module:
![image](https://github.com/user-attachments/assets/6209aee5-678b-4694-9b8e-587622cfc9a5)

![image](https://github.com/user-attachments/assets/d22ab577-2074-4e5f-8a25-b7f7009a3f18)