### PR TITLE
feat(cc_gwlb_asg): add default tags to global tags

### DIFF
--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -9,14 +9,23 @@ resource "random_string" "suffix" {
 
 
 ################################################################################
+# Retrieve the default tags from provider
+################################################################################
+data "aws_default_tags" "current" {}
+
+
+################################################################################
 # Map default tags with values to be assigned to all tagged resources
 ################################################################################
 locals {
-  global_tags = {
-    Owner     = var.owner_tag
-    ManagedBy = "terraform"
-    Vendor    = "Zscaler"
-  }
+  global_tags = merge(
+    {
+      Owner     = var.owner_tag
+      ManagedBy = "terraform"
+      Vendor    = "Zscaler"
+    },
+    data.aws_default_tags.current.tags
+  )
 }
 
 


### PR DESCRIPTION
This is a proposition in order to tag all resources with default tags from AWS provider.