### PR TITLE
IAM Policy least privilege best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 BUG FIXES:
 * fix: add explicit egress udp/53 rules to security group module
+* fix: add IAM Policy least privilege best practices
+    - add variable asg_arns to restrict CC and Lambda ASG lifecycle actions to self ASG
+    - add variable iam_tags_condition for optional customization of data.aws_iam_policy_document.cc_tags_policy_document
+    - split all IAM Policies into separate CREATE/PUT/DELETE vs GET/LIST/DESCRIBE statements
+    - add Zscaler specific namespace condition constraint to data.aws_iam_policy_document.cc_metrics_policy_document
 
 ## 1.4.0 (November 12, 2024)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
     - add variable iam_tags_condition for optional customization of data.aws_iam_policy_document.cc_tags_policy_document
     - split all IAM Policies into separate CREATE/PUT/DELETE vs GET/LIST/DESCRIBE statements
     - add Zscaler specific namespace condition constraint to data.aws_iam_policy_document.cc_metrics_policy_document
+    - update CCAllowTags minimum SQS/SNS IAM Policy dependencies
 
 ## 1.4.0 (November 12, 2024)
 FEATURES:

--- a/examples/base_cc_gwlb_asg/main.tf
+++ b/examples/base_cc_gwlb_asg/main.tf
@@ -193,7 +193,18 @@ module "cc_iam" {
   asg_enabled        = var.asg_enabled
   secret_name        = var.secret_name
   cloud_tags_enabled = var.cloud_tags_enabled
-  #asg_arns           = module.cc_asg.autoscaling_group_arn
+  asg_arns           = module.cc_asg.autoscaling_group_arn
+
+  #Example IAM Policy conditions that can apply to data.aws_iam_policy_document.cc_tags_policy_document
+  /*
+  iam_tags_condition = {
+    default = {
+      test = "StringLike"
+      variable = "aws:TagKeys"
+      values = ["example-tag-value"]
+    }
+  }
+  */
 }
 
 

--- a/examples/base_cc_gwlb_asg/main.tf
+++ b/examples/base_cc_gwlb_asg/main.tf
@@ -193,6 +193,7 @@ module "cc_iam" {
   asg_enabled        = var.asg_enabled
   secret_name        = var.secret_name
   cloud_tags_enabled = var.cloud_tags_enabled
+  #asg_arns           = module.cc_asg.autoscaling_group_arn
 }
 
 
@@ -267,6 +268,7 @@ module "asg_lambda" {
   autoscaling_group_names = module.cc_asg.autoscaling_group_ids
   asg_lambda_filename     = var.asg_lambda_filename
   runtime                 = local.python3_11_restricted_regions ? "python3.11" : "python3.12"
+  asg_arns                = module.cc_asg.autoscaling_group_arn
 }
 
 #default lambda runtime should be python3.12, except for China and Gov regions that only support python3.11

--- a/examples/base_cc_gwlb_asg_zpa/main.tf
+++ b/examples/base_cc_gwlb_asg_zpa/main.tf
@@ -195,6 +195,7 @@ module "cc_iam" {
   asg_enabled        = var.asg_enabled
   secret_name        = var.secret_name
   cloud_tags_enabled = var.cloud_tags_enabled
+  asg_arns           = module.cc_asg.autoscaling_group_arn
 }
 
 
@@ -287,6 +288,7 @@ module "asg_lambda" {
   autoscaling_group_names = module.cc_asg.autoscaling_group_ids
   asg_lambda_filename     = var.asg_lambda_filename
   runtime                 = local.python3_11_restricted_regions ? "python3.11" : "python3.12"
+  asg_arns                = module.cc_asg.autoscaling_group_arn
 }
 
 #default lambda runtime should be python3.12, except for China and Gov regions that only support python3.11

--- a/examples/base_cc_gwlb_asg_zpa/main.tf
+++ b/examples/base_cc_gwlb_asg_zpa/main.tf
@@ -196,6 +196,17 @@ module "cc_iam" {
   secret_name        = var.secret_name
   cloud_tags_enabled = var.cloud_tags_enabled
   asg_arns           = module.cc_asg.autoscaling_group_arn
+
+  #Example IAM Policy conditions that can apply to data.aws_iam_policy_document.cc_tags_policy_document
+  /*
+  iam_tags_condition = {
+    default = {
+      test = "StringLike"
+      variable = "aws:TagKeys"
+      values = ["example-notag-value"]
+    }
+  }
+  */
 }
 
 

--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -179,6 +179,17 @@ module "cc_iam" {
   cloud_tags_enabled = var.cloud_tags_enabled
   asg_arns           = module.cc_asg.autoscaling_group_arn
 
+  #Example IAM Policy conditions that can apply to data.aws_iam_policy_document.cc_tags_policy_document
+  /*
+  iam_tags_condition = {
+    default = {
+      test = "StringLike"
+      variable = "aws:TagKeys"
+      values = ["example-notag-value"]
+    }
+  }
+  */
+
   byo_iam = var.byo_iam
   # optional inputs. only required if byo_iam set to true
   byo_iam_instance_profile_id = var.byo_iam_instance_profile_id

--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -177,6 +177,7 @@ module "cc_iam" {
   asg_enabled        = var.asg_enabled
   secret_name        = var.secret_name
   cloud_tags_enabled = var.cloud_tags_enabled
+  asg_arns           = module.cc_asg.autoscaling_group_arn
 
   byo_iam = var.byo_iam
   # optional inputs. only required if byo_iam set to true
@@ -283,6 +284,7 @@ module "asg_lambda" {
   autoscaling_group_names = module.cc_asg.autoscaling_group_ids
   asg_lambda_filename     = var.asg_lambda_filename
   runtime                 = local.python3_11_restricted_regions ? "python3.11" : "python3.12"
+  asg_arns                = module.cc_asg.autoscaling_group_arn
 }
 
 #default lambda runtime should be python3.12, except for China and Gov regions that only support python3.11

--- a/modules/terraform-zscc-asg-aws/README.md
+++ b/modules/terraform-zscc-asg-aws/README.md
@@ -104,6 +104,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_autoscaling_group_arn"></a> [autoscaling\_group\_arn](#output\_autoscaling\_group\_arn) | Autoscaling group ARN |
 | <a name="output_autoscaling_group_ids"></a> [autoscaling\_group\_ids](#output\_autoscaling\_group\_ids) | Autoscaling group ID |
 | <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | Availability zones used for ASG |
 | <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | Autoscaling Launch Template ID |

--- a/modules/terraform-zscc-asg-aws/outputs.tf
+++ b/modules/terraform-zscc-asg-aws/outputs.tf
@@ -8,6 +8,11 @@ output "autoscaling_group_ids" {
   value       = aws_autoscaling_group.cc_asg[*].id
 }
 
+output "autoscaling_group_arn" {
+  description = "Autoscaling group ARN"
+  value       = aws_autoscaling_group.cc_asg[*].arn
+}
+
 output "launch_template_id" {
   description = "Autoscaling Launch Template ID"
   value       = aws_launch_template.cc_launch_template[0].id

--- a/modules/terraform-zscc-asg-lambda-aws/README.md
+++ b/modules/terraform-zscc-asg-lambda-aws/README.md
@@ -61,6 +61,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | The architecture for the Lambda function (x86\_64 or arm64) | `string` | `"arm64"` | no |
+| <a name="input_asg_arns"></a> [asg\_arns](#input\_asg\_arns) | Recommended: Cloud Connector Autoscaling Group ARN(s) provided for IAM Policy Lifecycle least privilege. If no ARNs are provided, IAM Policy will default to any | `list(string)` | `null` | no |
 | <a name="input_asg_lambda_filename"></a> [asg\_lambda\_filename](#input\_asg\_lambda\_filename) | Name of the lambda zip file without zip suffix | `string` | `"zscaler_cc_lambda_service"` | no |
 | <a name="input_autoscaling_group_names"></a> [autoscaling\_group\_names](#input\_autoscaling\_group\_names) | List of Autoscaling Group Names in a given Cloud Connector cluster/VPC for Lambda to monitor | `list(string)` | n/a | yes |
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |

--- a/modules/terraform-zscc-asg-lambda-aws/main.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/main.tf
@@ -65,16 +65,24 @@ data "aws_iam_policy_document" "lambda_autoscale_lifecycle_policy_document" {
     sid    = "LambdaAllowAutoscaleLifecycleActions"
     effect = "Allow"
     actions = [
-      "autoscaling:DescribeLifecycleHookTypes",
-      "autoscaling:DescribeLifecycleHooks",
-      "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:CompleteLifecycleAction",
       "autoscaling:RecordLifecycleActionHeartbeat",
       "autoscaling:SetInstanceHealth",
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeWarmPool",
+    ]
+    #Restrict autoscaling actions to only your own ASG(s) if var.asg_arns provided. Else, default to any
+    resources = coalesce(var.asg_arns, ["*"])
+  }
+  statement {
+    sid    = "LambdaAllowDescribe"
+    effect = "Allow"
+    actions = [
       "ec2:DescribeInstanceStatus",
-      "ec2:DescribeInstances"
+      "ec2:DescribeInstances",
+      "autoscaling:DescribeLifecycleHookTypes",
+      "autoscaling:DescribeLifecycleHooks",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeWarmPool"
     ]
     resources = ["*"]
   }

--- a/modules/terraform-zscc-asg-lambda-aws/main.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/main.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "lambda_autoscale_lifecycle_policy_document" {
       "autoscaling:SetInstanceHealth",
     ]
     #Restrict autoscaling actions to only your own ASG(s) if var.asg_arns provided. Else, default to any
-    resources = coalesce(var.asg_arns, ["*"])
+    resources = coalescelist(var.asg_arns, ["*"])
   }
   statement {
     sid    = "LambdaAllowDescribe"

--- a/modules/terraform-zscc-asg-lambda-aws/variables.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/variables.tf
@@ -64,3 +64,8 @@ variable "runtime" {
     error_message = "Invalid architecture. Must be either 'python3.11' or 'python3.12'."
   }
 }
+variable "asg_arns" {
+  type        = list(string)
+  description = "Recommended: Cloud Connector Autoscaling Group ARN(s) provided for IAM Policy Lifecycle least privilege. If no ARNs are provided, IAM Policy will default to any"
+  default     = null
+}

--- a/modules/terraform-zscc-iam-aws/README.md
+++ b/modules/terraform-zscc-iam-aws/README.md
@@ -49,12 +49,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_asg_arns"></a> [asg\_arns](#input\_asg\_arns) | Recommended: Cloud Connector Autoscaling Group ARN(s) provided for IAM Policy Lifecycle least privilege. If no ARNs are provided, IAM Policy will default to any | `list(string)` | `null` | no |
 | <a name="input_asg_enabled"></a> [asg\_enabled](#input\_asg\_enabled) | Determines whether or not to create the cc\_autoscale\_lifecycle\_policy IAM Policy and attach it to the CC IAM Role | `bool` | `false` | no |
 | <a name="input_byo_iam"></a> [byo\_iam](#input\_byo\_iam) | Bring your own IAM Instance Profile for Cloud Connector. Setting this variable to true will effectively instruct this module to not create any resources and only reference data resources from values provided in byo\_iam\_instance\_profile\_id | `bool` | `false` | no |
 | <a name="input_byo_iam_instance_profile_id"></a> [byo\_iam\_instance\_profile\_id](#input\_byo\_iam\_instance\_profile\_id) | Existing IAM Instance Profile IDs for Cloud Connector association | `list(string)` | `null` | no |
 | <a name="input_cloud_tags_enabled"></a> [cloud\_tags\_enabled](#input\_cloud\_tags\_enabled) | Determines whether or not to create the cc\_tags\_policy IAM Policy and attach it to the CC IAM Role | `bool` | `false` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Populate any custom user defined tags from a map | `map(string)` | `{}` | no |
 | <a name="input_iam_count"></a> [iam\_count](#input\_iam\_count) | Default number IAM roles/policies/profiles to create | `number` | `1` | no |
+| <a name="input_iam_tags_condition"></a> [iam\_tags\_condition](#input\_iam\_tags\_condition) | Optional - customizable conditions map to be used with IAM policies such as KeyTag validation | <pre>map(object({<br/>    test     = string<br/>    variable = string<br/>    values   = list(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A prefix to associate to all the Cloud Connector IAM module resources | `string` | `null` | no |
 | <a name="input_resource_tag"></a> [resource\_tag](#input\_resource\_tag) | A tag to associate to all the Cloud Connector IAM module resources | `string` | `null` | no |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | AWS Secrets Manager Secret Name for Cloud Connector provisioning | `string` | n/a | yes |

--- a/modules/terraform-zscc-iam-aws/main.tf
+++ b/modules/terraform-zscc-iam-aws/main.tf
@@ -114,7 +114,7 @@ data "aws_iam_policy_document" "cc_autoscale_lifecycle_policy_document" {
       "autoscaling:RecordLifecycleActionHeartbeat"
     ]
     #Restrict autoscaling actions to only your own ASG(s) if var.asg_arns provided. Else, default to any
-    resources = coalesce(var.asg_arns, ["*"])
+    resources = coalescelist(var.asg_arns, ["*"])
   }
 }
 

--- a/modules/terraform-zscc-iam-aws/main.tf
+++ b/modules/terraform-zscc-iam-aws/main.tf
@@ -194,16 +194,12 @@ data "aws_iam_policy_document" "cc_tags_policy_document" {
     sid    = "CCAllowTags"
     effect = "Allow"
     actions = [
-      "sqs:DeleteMessage",
-      "sqs:ReceiveMessage",
-      "sqs:GetQueueUrl",
-      "sqs:GetQueueAttributes",
-      "sqs:SetQueueAttributes",
-      "sqs:DeleteQueue",
-      "sqs:CreateQueue",
+      "sns:ListTopics",
       "sns:ListSubscriptions",
       "sns:Subscribe",
-      "sns:Unsubscribe"
+      "sns:Unsubscribe",
+      "sqs:CreateQueue",
+      "sqs:DeleteQueue"
     ]
     resources = ["*"]
 

--- a/modules/terraform-zscc-iam-aws/variables.tf
+++ b/modules/terraform-zscc-iam-aws/variables.tf
@@ -50,3 +50,19 @@ variable "cloud_tags_enabled" {
   description = "Determines whether or not to create the cc_tags_policy IAM Policy and attach it to the CC IAM Role"
   default     = false
 }
+
+variable "asg_arns" {
+  type        = list(string)
+  description = "Recommended: Cloud Connector Autoscaling Group ARN(s) provided for IAM Policy Lifecycle least privilege. If no ARNs are provided, IAM Policy will default to any"
+  default     = null
+}
+
+variable "iam_tags_condition" {
+  type = map(object({
+    test     = string
+    variable = string
+    values   = list(string)
+  }))
+  description = "Optional - customizable conditions map to be used with IAM policies such as KeyTag validation"
+  default     = {}
+}


### PR DESCRIPTION
BUG FIXES:
* fix: add explicit egress udp/53 rules to security group module
* fix: add IAM Policy least privilege best practices
    - add variable asg_arns to restrict CC and Lambda ASG lifecycle actions to self ASG
    - add variable iam_tags_condition for optional customization of data.aws_iam_policy_document.cc_tags_policy_document
    - split all IAM Policies into separate CREATE/PUT/DELETE vs GET/LIST/DESCRIBE statements
    - add Zscaler specific namespace condition constraint to data.aws_iam_policy_document.cc_metrics_policy_document