### PR TITLE
ZTW-9053: TF-AWS-04 constrain ec2:ReplaceRoute to deployment-tagged route …

### DIFF
--- a/modules/terraform-zscc-lambda-aws/main.tf
+++ b/modules/terraform-zscc-lambda-aws/main.tf
@@ -36,6 +36,7 @@ resource "aws_iam_policy" "iam_policy_for_cc_lambda" {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "EC2ReadAndNetworkInterface",
       "Action": [
         "ec2:AssignPrivateIpAddresses",
         "ec2:CreateNetworkInterface",
@@ -46,7 +47,6 @@ resource "aws_iam_policy" "iam_policy_for_cc_lambda" {
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstanceStatus",
         "ec2:DescribeRouteTables",
-        "ec2:ReplaceRoute",
         "ec2:UnassignPrivateIpAddresses",
         "lambda:InvokeFunction",
         "logs:CreateLogStream",
@@ -54,6 +54,19 @@ resource "aws_iam_policy" "iam_policy_for_cc_lambda" {
       ],
       "Effect": "Allow",
       "Resource": "*"
+    },
+    {
+      "Sid": "EC2ReplaceRouteTaggedOnly",
+      "Action": [
+        "ec2:ReplaceRoute"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/Name": "${var.name_prefix}-*-rt-${var.resource_tag}"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
TF-AWS-04 (HIGH, CWE-732):
 
The iam_policy_for_cc_lambda IAM policy granted ec2:ReplaceRoute on
Resource:'*' with no condition. A compromised Lambda or any principal
able to update its code/env could rewrite the default route of ANY
route table in the account to an ENI they control, silently
intercepting traffic from VPCs unrelated to Cloud Connector.
 
Fix: Split the single broad statement into two:
- EC2ReadAndNetworkInterface: all read/describe + network interface
  actions remain on Resource:'*' (required by AWS for Describe calls)
- EC2ReplaceRouteTaggedOnly: ec2:ReplaceRoute restricted via a
  StringLike condition on ec2:ResourceTag/Name matching the pattern
  '\${var.name_prefix}-*-rt-\${var.resource_tag}', which covers only
  the workload route tables created by this deployment.
 
Verified: JSON valid, terraform validate passes, StringLike pattern
correctly allows own deployment RTs and denies all others."