### PR TITLE
Support AWS provider v6 and secondary VPC CIDRs in Cloud Connector security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cloud (VPC). The [examples](examples/) directory contains complete automation sc
 The AWS Terraform scripts leverage Terraform v1.1.9 which includes full binary and provider support for macOS M1 chips, but any Terraform
 version 0.13.7 should be generally supported.
 
--   provider registry.terraform.io/hashicorp/aws v5.49.x (minimum 5.32.0)
+-   provider registry.terraform.io/hashicorp/aws v6.x (minimum 6.10.0)
 -   provider registry.terraform.io/hashicorp/random v3.3.x
 -   provider registry.terraform.io/hashicorp/local v2.2.x
 -   provider registry.terraform.io/hashicorp/null v3.1.x

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -38,7 +38,7 @@ From base directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -48,7 +48,7 @@ From base directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0.0 |

--- a/examples/base/versions.tf
+++ b/examples/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc/README.md
+++ b/examples/base_1cc/README.md
@@ -40,7 +40,7 @@ From base_1cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -50,7 +50,7 @@ From base_1cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -85,6 +85,7 @@ From base_1cc directory execute:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |

--- a/examples/base_1cc/main.tf
+++ b/examples/base_1cc/main.tf
@@ -184,18 +184,19 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  gwlb_enabled             = false
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  gwlb_enabled               = false
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_1cc/variables.tf
+++ b/examples/base_1cc/variables.tf
@@ -175,6 +175,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_1cc/versions.tf
+++ b/examples/base_1cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_1cc_zpa/README.md
+++ b/examples/base_1cc_zpa/README.md
@@ -40,7 +40,7 @@ From base_1cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -50,7 +50,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -86,6 +86,7 @@ From base_1cc_zpa directory execute:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |

--- a/examples/base_1cc_zpa/main.tf
+++ b/examples/base_1cc_zpa/main.tf
@@ -185,19 +185,20 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  gwlb_enabled             = false
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  gwlb_enabled               = false
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_1cc_zpa/variables.tf
+++ b/examples/base_1cc_zpa/variables.tf
@@ -198,6 +198,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_1cc_zpa/versions.tf
+++ b/examples/base_1cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc/README.md
+++ b/examples/base_2cc/README.md
@@ -42,7 +42,7 @@ From base_2cc directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -52,7 +52,7 @@ From base_2cc directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -88,6 +88,7 @@ From base_2cc directory execute:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |

--- a/examples/base_2cc/main.tf
+++ b/examples/base_2cc/main.tf
@@ -183,18 +183,19 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  gwlb_enabled             = false
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  gwlb_enabled               = false
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_2cc/variables.tf
+++ b/examples/base_2cc/variables.tf
@@ -175,6 +175,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_2cc/versions.tf
+++ b/examples/base_2cc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_2cc_zpa/README.md
+++ b/examples/base_2cc_zpa/README.md
@@ -41,7 +41,7 @@ From base_2cc_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -51,7 +51,7 @@ From base_2cc_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -88,6 +88,7 @@ From base_2cc_zpa directory execute:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |

--- a/examples/base_2cc_zpa/main.tf
+++ b/examples/base_2cc_zpa/main.tf
@@ -184,19 +184,20 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  gwlb_enabled             = false
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  gwlb_enabled               = false
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_2cc_zpa/variables.tf
+++ b/examples/base_2cc_zpa/variables.tf
@@ -198,6 +198,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_2cc_zpa/versions.tf
+++ b/examples/base_2cc_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb/README.md
+++ b/examples/base_cc_gwlb/README.md
@@ -101,7 +101,7 @@ From base_cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -111,7 +111,7 @@ From base_cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -149,6 +149,7 @@ From base_cc_gwlb directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/base_cc_gwlb/main.tf
+++ b/examples/base_cc_gwlb/main.tf
@@ -187,17 +187,18 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_cc_gwlb/variables.tf
+++ b/examples/base_cc_gwlb/variables.tf
@@ -244,6 +244,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_cc_gwlb/versions.tf
+++ b/examples/base_cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg/README.md
+++ b/examples/base_cc_gwlb_asg/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -88,6 +88,7 @@ From base_cc_gwlb_asg directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a launch template change. | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/base_cc_gwlb_asg/main.tf
+++ b/examples/base_cc_gwlb_asg/main.tf
@@ -214,16 +214,17 @@ module "cc_iam" {
 #    interface(s)
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_cc_gwlb_asg/variables.tf
+++ b/examples/base_cc_gwlb_asg/variables.tf
@@ -157,6 +157,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_cc_gwlb_asg/versions.tf
+++ b/examples/base_cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_asg_zpa/README.md
+++ b/examples/base_cc_gwlb_asg_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -89,6 +89,7 @@ From base_cc_gwlb_asg_zpa directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a launch template change. | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/base_cc_gwlb_asg_zpa/main.tf
+++ b/examples/base_cc_gwlb_asg_zpa/main.tf
@@ -216,17 +216,18 @@ module "cc_iam" {
 #    interface(s)
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_cc_gwlb_asg_zpa/variables.tf
+++ b/examples/base_cc_gwlb_asg_zpa/variables.tf
@@ -169,6 +169,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_cc_gwlb_asg_zpa/versions.tf
+++ b/examples/base_cc_gwlb_asg_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/base_cc_gwlb_zpa/README.md
+++ b/examples/base_cc_gwlb_zpa/README.md
@@ -39,7 +39,7 @@ From base_cc_gwlb_zpa directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -49,7 +49,7 @@ From base_cc_gwlb_zpa directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -88,6 +88,7 @@ From base_cc_gwlb_zpa directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/base_cc_gwlb_zpa/main.tf
+++ b/examples/base_cc_gwlb_zpa/main.tf
@@ -186,18 +186,19 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 }
 
 

--- a/examples/base_cc_gwlb_zpa/variables.tf
+++ b/examples/base_cc_gwlb_zpa/variables.tf
@@ -267,6 +267,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/base_cc_gwlb_zpa/versions.tf
+++ b/examples/base_cc_gwlb_zpa/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb/README.md
+++ b/examples/cc_gwlb/README.md
@@ -38,7 +38,7 @@ From cc_gwlb directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -48,7 +48,7 @@ From cc_gwlb directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -84,6 +84,7 @@ From cc_gwlb directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/cc_gwlb/main.tf
+++ b/examples/cc_gwlb/main.tf
@@ -173,18 +173,19 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 
   byo_security_group = var.byo_security_group
   # optional inputs. only required if byo_security_group set to true

--- a/examples/cc_gwlb/variables.tf
+++ b/examples/cc_gwlb/variables.tf
@@ -256,6 +256,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/cc_gwlb/versions.tf
+++ b/examples/cc_gwlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_gwlb_asg/README.md
+++ b/examples/cc_gwlb_asg/README.md
@@ -37,7 +37,7 @@ From cc_gwlb_asg directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -47,7 +47,7 @@ From cc_gwlb_asg directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -84,6 +84,7 @@ From cc_gwlb_asg directory execute:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceptance_required"></a> [acceptance\_required](#input\_acceptance\_required) | Whether to require manual acceptance of any VPC Endpoint registration attempts to the Endpoint Service or not. Default is false | `bool` | `false` | no |
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | List of AWS Principal ARNs who are allowed access to the GWLB Endpoint Service. E.g. ["arn:aws:iam::1234567890:root"]`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a launch template change. | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |

--- a/examples/cc_gwlb_asg/main.tf
+++ b/examples/cc_gwlb_asg/main.tf
@@ -203,17 +203,18 @@ module "cc_iam" {
 #    interface(s)
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 
   byo_security_group = var.byo_security_group
   # optional inputs. only required if byo_security_group set to true

--- a/examples/cc_gwlb_asg/variables.tf
+++ b/examples/cc_gwlb_asg/variables.tf
@@ -145,6 +145,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/cc_gwlb_asg/versions.tf
+++ b/examples/cc_gwlb_asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/cc_ha/README.md
+++ b/examples/cc_ha/README.md
@@ -42,7 +42,7 @@ From cc_ha directory execute:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
@@ -52,7 +52,7 @@ From cc_ha directory execute:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32.0, <= 5.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6.0 |
@@ -86,6 +86,7 @@ From cc_ha directory execute:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID(s) to be used for deploying Cloud Connector appliances. Ideally all VMs should be on the same AMI ID as templates always pull the latest from AWS Marketplace. This variable is provided if a customer desires to override/retain an old ami for existing deployments rather than upgrading and forcing a replacement. It is also inputted as a list to facilitate if a customer desired to manually upgrade select CCs deployed based on the cc\_count index | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region. | `string` | `"us-west-2"` | no |

--- a/examples/cc_ha/main.tf
+++ b/examples/cc_ha/main.tf
@@ -172,19 +172,20 @@ module "cc_iam" {
 #    security group created and assigned to ALL Cloud Connectors instead.
 ################################################################################
 module "cc_sg" {
-  source                   = "../../modules/terraform-zscc-sg-aws"
-  sg_count                 = var.reuse_security_group == false ? var.cc_count : 1
-  name_prefix              = var.name_prefix
-  resource_tag             = random_string.suffix.result
-  global_tags              = local.global_tags
-  vpc_id                   = module.network.vpc_id
-  zpa_enabled              = var.zpa_enabled
-  http_probe_port          = var.http_probe_port
-  mgmt_ssh_enabled         = var.mgmt_ssh_enabled
-  gwlb_enabled             = false
-  all_ports_egress_enabled = var.all_ports_egress_enabled
-  support_access_enabled   = var.support_access_enabled
-  zssupport_server         = var.zssupport_server
+  source                     = "../../modules/terraform-zscc-sg-aws"
+  sg_count                   = var.reuse_security_group == false ? var.cc_count : 1
+  name_prefix                = var.name_prefix
+  resource_tag               = random_string.suffix.result
+  global_tags                = local.global_tags
+  vpc_id                     = module.network.vpc_id
+  zpa_enabled                = var.zpa_enabled
+  http_probe_port            = var.http_probe_port
+  mgmt_ssh_enabled           = var.mgmt_ssh_enabled
+  gwlb_enabled               = false
+  all_ports_egress_enabled   = var.all_ports_egress_enabled
+  support_access_enabled     = var.support_access_enabled
+  zssupport_server           = var.zssupport_server
+  additional_intra_vpc_cidrs = var.additional_intra_vpc_cidrs
 
   byo_security_group = var.byo_security_group
   # optional inputs. only required if byo_security_group set to true

--- a/examples/cc_ha/variables.tf
+++ b/examples/cc_ha/variables.tf
@@ -193,6 +193,12 @@ variable "mgmt_ssh_enabled" {
   default     = true
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "all_ports_egress_enabled" {
   type        = bool
   default     = true

--- a/examples/cc_ha/versions.tf
+++ b/examples/cc_ha/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0, <= 5.49.0"
+      version = ">= 6.10.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/terraform-zscc-asg-aws/README.md
+++ b/modules/terraform-zscc-asg-aws/README.md
@@ -23,7 +23,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0, < 2.6 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1, < 3.3 |
 
@@ -31,7 +31,7 @@ If sns_enabled to set to true where an sns topic AND sns topic subscription (for
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1, < 3.3 |
 
 ## Modules

--- a/modules/terraform-zscc-asg-aws/versions.tf
+++ b/modules/terraform-zscc-asg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-asg-lambda-aws/README.md
+++ b/modules/terraform-zscc-asg-lambda-aws/README.md
@@ -17,13 +17,13 @@ This module creates the Lambda Function, IAM Policies, and Cloudwatch Events/Tar
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-asg-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-asg-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-bastion-aws/README.md
+++ b/modules/terraform-zscc-bastion-aws/README.md
@@ -8,13 +8,13 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-bastion-aws/versions.tf
+++ b/modules/terraform-zscc-bastion-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-ccvm-aws/README.md
+++ b/modules/terraform-zscc-ccvm-aws/README.md
@@ -19,7 +19,7 @@ Subscribe and accept terms of using Zscaler Cloud Connector image at [this link]
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0, < 2.6 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1, < 3.3 |
 
@@ -27,7 +27,7 @@ Subscribe and accept terms of using Zscaler Cloud Connector image at [this link]
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1, < 3.3 |
 
 ## Modules

--- a/modules/terraform-zscc-ccvm-aws/main.tf
+++ b/modules/terraform-zscc-ccvm-aws/main.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "cc_vm" {
   instance_type        = var.ccvm_instance_type
   iam_instance_profile = element(var.iam_instance_profile, count.index)
   key_name             = var.instance_key
-  user_data            = base64encode(var.user_data)
+  user_data_base64     = base64encode(base64encode(var.user_data))
   ebs_optimized        = true
 
   metadata_options {
@@ -44,8 +44,7 @@ resource "aws_instance" "cc_vm" {
     http_tokens   = var.imdsv2_enabled ? "required" : "optional"
   }
 
-  network_interface {
-    device_index         = 0
+  primary_network_interface {
     network_interface_id = aws_network_interface.cc_vm_nic_index_0[count.index].id
   }
 

--- a/modules/terraform-zscc-ccvm-aws/versions.tf
+++ b/modules/terraform-zscc-ccvm-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-gwlb-aws/README.md
+++ b/modules/terraform-zscc-gwlb-aws/README.md
@@ -8,13 +8,13 @@ This module creates a Gateway Load Balancer (GWLB) and Listener resource. It als
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-gwlb-aws/versions.tf
+++ b/modules/terraform-zscc-gwlb-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-gwlbendpoint-aws/README.md
+++ b/modules/terraform-zscc-gwlbendpoint-aws/README.md
@@ -8,13 +8,13 @@ This module creates Gateway Load Balancer Endpoint (GWLBE) and VPC Endpoint Serv
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
+++ b/modules/terraform-zscc-gwlbendpoint-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-iam-aws/README.md
+++ b/modules/terraform-zscc-iam-aws/README.md
@@ -22,13 +22,13 @@ This module creates IAM Policies, Roles, and Instance Profile resources required
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-iam-aws/versions.tf
+++ b/modules/terraform-zscc-iam-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-lambda-aws/README.md
+++ b/modules/terraform-zscc-lambda-aws/README.md
@@ -12,14 +12,14 @@ This module creates all the necessary IAM Roles/Polices, Lambda Functions/Permis
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0, < 2.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-lambda-aws/versions.tf
+++ b/modules/terraform-zscc-lambda-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-network-aws/README.md
+++ b/modules/terraform-zscc-network-aws/README.md
@@ -8,14 +8,14 @@ This module has multi-purpose use and is leveraged by all other Zscaler Cloud Co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0, < 2.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-network-aws/versions.tf
+++ b/modules/terraform-zscc-network-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/terraform-zscc-route53-aws/README.md
+++ b/modules/terraform-zscc-route53-aws/README.md
@@ -12,13 +12,13 @@ This module can create multiple Route 53 Outbound Endpoints and Resolver Rules a
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 

--- a/modules/terraform-zscc-route53-aws/versions.tf
+++ b/modules/terraform-zscc-route53-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-sg-aws/README.md
+++ b/modules/terraform-zscc-sg-aws/README.md
@@ -8,13 +8,13 @@ This module creates Security Rules and Groups resources required for successful 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 
 ## Modules
 
@@ -34,6 +34,7 @@ No modules.
 | [aws_vpc_security_group_egress_rule.egress_cc_mgmt_udp_53](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_cc_service_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_cc_service_geneve](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.egress_cc_service_geneve_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_cc_service_tcp_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_cc_service_udp_123](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_cc_service_udp_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
@@ -41,10 +42,15 @@ No modules.
 | [aws_vpc_security_group_egress_rule.egress_outbound_endpoint_tcp_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.egress_outbound_endpoint_udp_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.cc_mgmt_ingress_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.cc_mgmt_ingress_ssh_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_cc_service_all_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_geneve](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_cc_service_geneve_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_cc_service_health_check_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_cc_service_https_local](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_cc_service_https_local_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_outbound_endpoint_tcp_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ingress_outbound_endpoint_udp_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_security_group.cc_mgmt_sg_selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
@@ -56,6 +62,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_intra_vpc_cidrs"></a> [additional\_intra\_vpc\_cidrs](#input\_additional\_intra\_vpc\_cidrs) | Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws\_vpc.selected.cidr\_block. Value ignored if not creating a security group | `list(string)` | `[]` | no |
 | <a name="input_all_ports_egress_enabled"></a> [all\_ports\_egress\_enabled](#input\_all\_ports\_egress\_enabled) | Default is true which creates an egress rule permitting the CC service interface to forward direct traffic on all ports and protocols. If false, the rule is not created. Value ignored if not creating a security group | `bool` | `true` | no |
 | <a name="input_byo_mgmt_security_group_id"></a> [byo\_mgmt\_security\_group\_id](#input\_byo\_mgmt\_security\_group\_id) | Management Security Group ID for Cloud Connector association | `list(string)` | `null` | no |
 | <a name="input_byo_route53_resolver_outbound_endpoint_group_id"></a> [byo\_route53\_resolver\_outbound\_endpoint\_group\_id](#input\_byo\_route53\_resolver\_outbound\_endpoint\_group\_id) | Route53 Resolver Outbound Endpoint Security Group ID | `list(string)` | `null` | no |

--- a/modules/terraform-zscc-sg-aws/main.tf
+++ b/modules/terraform-zscc-sg-aws/main.tf
@@ -5,6 +5,21 @@ data "aws_vpc" "selected" {
   id = var.vpc_id
 }
 
+locals {
+  # Cartesian product of each security group (by sg_count index) and every
+  # additional intra-VPC CIDR provided via var.additional_intra_vpc_cidrs.
+  # Used to create supplementary security group rules when Cloud Connector
+  # and/or the GWLB reside in a secondary VPC CIDR that is not returned by
+  # data.aws_vpc.selected.cidr_block. Empty when bringing your own security group.
+  additional_intra_vpc_cidrs = var.byo_security_group == false ? {
+    for pair in setproduct(range(var.sg_count), var.additional_intra_vpc_cidrs) :
+    "${pair[0]}-${pair[1]}" => {
+      sg_index = pair[0]
+      cidr     = pair[1]
+    }
+  } : {}
+}
+
 
 ################################################################################
 # Create Security Group and Rules for Cloud Connector Management Interfaces
@@ -32,6 +47,17 @@ resource "aws_vpc_security_group_ingress_rule" "cc_mgmt_ingress_ssh" {
   description       = "Recommended: SSH to CC management"
   security_group_id = aws_security_group.cc_mgmt_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
+  from_port         = 22
+  ip_protocol       = "tcp"
+  to_port           = 22
+}
+
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for SSH to CC management
+resource "aws_vpc_security_group_ingress_rule" "cc_mgmt_ingress_ssh_additional" {
+  for_each          = var.mgmt_ssh_enabled ? local.additional_intra_vpc_cidrs : {}
+  description       = "Recommended: SSH to CC management from additional intra-VPC CIDR"
+  security_group_id = aws_security_group.cc_mgmt_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
   from_port         = 22
   ip_protocol       = "tcp"
   to_port           = 22
@@ -132,11 +158,33 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_health_check"
   to_port           = var.http_probe_port
 }
 
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for CC Service TCP health probe
+resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_health_check_additional" {
+  for_each          = local.additional_intra_vpc_cidrs
+  description       = "Required: CC Service TCP health probe from additional intra-VPC CIDR"
+  security_group_id = aws_security_group.cc_service_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
+  from_port         = var.http_probe_port
+  ip_protocol       = "tcp"
+  to_port           = var.http_probe_port
+}
+
 resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_https_local" {
   count             = var.byo_security_group == false ? var.sg_count : 0
   description       = "Required: CC inbound internal VPC cluster TCP 443 communication"
   security_group_id = aws_security_group.cc_service_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
+
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for internal VPC cluster TCP 443
+resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_https_local_additional" {
+  for_each          = local.additional_intra_vpc_cidrs
+  description       = "Required: CC inbound internal VPC cluster TCP 443 communication from additional intra-VPC CIDR"
+  security_group_id = aws_security_group.cc_service_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
   from_port         = 443
   ip_protocol       = "tcp"
   to_port           = 443
@@ -194,11 +242,33 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_geneve" {
   to_port           = 6081
 }
 
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for GENEVE ingress from GWLB
+resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_geneve_additional" {
+  for_each          = var.gwlb_enabled ? local.additional_intra_vpc_cidrs : {}
+  description       = "Required: CC GENEVE encapsulation traffic to CC Service from GWLB in additional intra-VPC CIDR"
+  security_group_id = aws_security_group.cc_service_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
+  from_port         = 6081
+  ip_protocol       = "udp"
+  to_port           = 6081
+}
+
 resource "aws_vpc_security_group_egress_rule" "egress_cc_service_geneve" {
   count             = var.byo_security_group == false && var.gwlb_enabled ? var.sg_count : 0
   description       = "Required: CC GENEVE encapsulation traffic to GWLB from CC Service"
   security_group_id = aws_security_group.cc_service_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
+  from_port         = 6081
+  ip_protocol       = "udp"
+  to_port           = 6081
+}
+
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for GENEVE egress to GWLB
+resource "aws_vpc_security_group_egress_rule" "egress_cc_service_geneve_additional" {
+  for_each          = var.gwlb_enabled ? local.additional_intra_vpc_cidrs : {}
+  description       = "Required: CC GENEVE encapsulation traffic to GWLB from CC Service in additional intra-VPC CIDR"
+  security_group_id = aws_security_group.cc_service_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
   from_port         = 6081
   ip_protocol       = "udp"
   to_port           = 6081
@@ -211,6 +281,15 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_all" {
   description       = "Optional: Permit All Intra-VPC Traffic / Ensure CC Service Interfaces are able to communicate with each other freely"
   security_group_id = aws_security_group.cc_service_sg[count.index].id
   cidr_ipv4         = data.aws_vpc.selected.cidr_block
+  ip_protocol       = "-1"
+}
+
+# Additional intra-VPC CIDRs (e.g. secondary VPC CIDR associations) for all intra-VPC traffic
+resource "aws_vpc_security_group_ingress_rule" "ingress_cc_service_all_additional" {
+  for_each          = local.additional_intra_vpc_cidrs
+  description       = "Optional: Permit All Traffic from additional intra-VPC CIDR / Ensure CC Service Interfaces can communicate freely"
+  security_group_id = aws_security_group.cc_service_sg[each.value.sg_index].id
+  cidr_ipv4         = each.value.cidr
   ip_protocol       = "-1"
 }
 

--- a/modules/terraform-zscc-sg-aws/variables.tf
+++ b/modules/terraform-zscc-sg-aws/variables.tf
@@ -70,6 +70,12 @@ variable "http_probe_port" {
   }
 }
 
+variable "additional_intra_vpc_cidrs" {
+  type        = list(string)
+  description = "Optional list of additional intra-VPC CIDR blocks (e.g. secondary VPC CIDR associations) to permit in the Cloud Connector security group rules. Use this when Cloud Connector and/or the GWLB reside in a secondary VPC CIDR that is not returned by data.aws_vpc.selected.cidr_block. Value ignored if not creating a security group"
+  default     = []
+}
+
 variable "gwlb_enabled" {
   type        = bool
   description = "Default is true which creates ingress/egress rules only for GENEVE traffic. If false, these rules are replaced with an allow all ports/protocols ingress. Value ignored if not creating a security group"

--- a/modules/terraform-zscc-sg-aws/versions.tf
+++ b/modules/terraform-zscc-sg-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-tgw-aws/README.md
+++ b/modules/terraform-zscc-tgw-aws/README.md
@@ -65,7 +65,7 @@ module "tgw" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.7, < 2.0.0 |
-| aws | ~> 5.32 |
+| aws | >= 6.10.0, < 7.0.0 |
 
 ## Inputs
 

--- a/modules/terraform-zscc-tgw-aws/versions.tf
+++ b/modules/terraform-zscc-tgw-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zscc-workload-aws/README.md
+++ b/modules/terraform-zscc-workload-aws/README.md
@@ -8,14 +8,14 @@ This module creates all AWS EC2 instance, IAM, and Security Group resources need
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0, < 2.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.10.0, < 7.0.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.2.0, < 2.6 |
 
 ## Modules

--- a/modules/terraform-zscc-workload-aws/versions.tf
+++ b/modules/terraform-zscc-workload-aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.32"
+      version = ">= 6.10.0, < 7.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
AWS provider v6 support:
- Bump aws provider constraint to ">= 6.10.0, < 7.0.0" across all modules and examples (6.10.0 is the minimum version providing primary_network_interface)
- terraform-zscc-ccvm-aws: replace the deprecated network_interface block with primary_network_interface, and use user_data_base64 instead of user_data (v6 no longer base64-encodes user_data automatically)

Secondary VPC CIDR support (terraform-zscc-sg-aws):
- Add optional additional_intra_vpc_cidrs variable (list(string), default []) for deployments where Cloud Connector and/or the GWLB reside in a secondary VPC CIDR association not returned by data.aws_vpc.selected.cidr_block
- Add matching *_additional ingress/egress rules (mgmt SSH, health check, https local, GENEVE ingress/egress, all intra-VPC) via for_each. Non-breaking: existing rules are unchanged, so no destroy/recreate on upgrade
- Plumb additional_intra_vpc_cidrs through all example root modules

Regenerate READMEs to reflect the new provider version, variable, and resources.

